### PR TITLE
Allow multi-line task content editing

### DIFF
--- a/Apps/todoist-sorter.html
+++ b/Apps/todoist-sorter.html
@@ -124,7 +124,7 @@
                 <div id="editor-content" class="space-y-6">
                     <div>
                         <label for="task-content-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Task</label>
-                        <input type="text" id="task-content-input" class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg p-3 text-lg font-medium focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <textarea id="task-content-input" rows="3" class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg p-3 text-lg font-medium focus:ring-2 focus:ring-blue-500 focus:border-blue-500"></textarea>
                     </div>
                     <div>
                         <label for="task-description-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description</label>


### PR DESCRIPTION
## Summary
- replace the single-line task editor input with a textarea so longer task titles fit without scrolling

## Testing
- not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_68c8ab173d8c8325b3668a3929489e90