### PR TITLE
Add AI nudge engine blog and surface it on site

### DIFF
--- a/blogs/ai-powered-nudge-engine-for-social-dining.html
+++ b/blogs/ai-powered-nudge-engine-for-social-dining.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>The Anatomy of an AI-Powered Nudge Engine for Social Dining - Chris Cruz</title>
+    <meta name="description" content="Dive into the data model, personalization workflows, and AWS architecture powering hyper-personalized nudges for a social dining app."/>
+    <meta name="keywords" content="AI nudge engine, social dining personalization, RAG workflow, AWS architecture, AI notifications"/>
+    <meta name="author" content="Chris Cruz"/>
+    <meta property="og:title" content="The Anatomy of an AI-Powered Nudge Engine for Social Dining"/>
+    <meta property="og:description" content="Explore how user and event vectors combine with RAG workflows to craft high-converting nudges for social dining."/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:url" content="https://chriscruz.ai/blogs/ai-powered-nudge-engine-for-social-dining.html"/>
+    <meta property="og:image" content="https://chriscruz.ai/images/ai-nudge-engine-preview.jpg"/>
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:title" content="The Anatomy of an AI-Powered Nudge Engine for Social Dining"/>
+    <meta name="twitter:description" content="A full breakdown of the personalization layers and KPIs behind a high-performing social dining notification engine."/>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #f8f9fa;
+        }
+        .chart-container {
+            position: relative;
+            width: 100%;
+            max-width: 500px;
+            margin-left: auto;
+            margin-right: auto;
+            height: 320px;
+            max-height: 350px;
+        }
+        @media (min-width: 768px) {
+            .chart-container {
+                height: 350px;
+                max-height: 400px;
+            }
+        }
+        .flow-line {
+            position: relative;
+            flex-grow: 1;
+            height: 2px;
+            background-color: #665191;
+            margin: 0 8px;
+        }
+        .flow-line::after {
+            content: '►';
+            position: absolute;
+            right: -10px;
+            top: 50%;
+            transform: translateY(-50%);
+            color: #665191;
+            font-size: 1.2rem;
+        }
+        .flow-line-vertical {
+            width: 2px;
+            background-color: #665191;
+            margin: 8px auto;
+            position: relative;
+        }
+        .flow-line-vertical::after {
+            content: '▼';
+            position: absolute;
+            bottom: -10px;
+            left: 50%;
+            transform: translateX(-50%);
+            color: #665191;
+            font-size: 1.2rem;
+        }
+        .kpi-stat {
+            font-size: 3rem;
+            font-weight: 900;
+            line-height: 1.1;
+            color: #d45087;
+        }
+    </style>
+</head>
+<body class="text-[#2f4b7c]">
+    <div class="container mx-auto max-w-7xl p-4 sm:p-6 md:p-12">
+        <nav class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-10 text-sm font-semibold">
+            <a href="../index.html" class="inline-flex items-center gap-1 text-[#d45087] hover:text-[#a05195] transition-colors">
+                <span aria-hidden="true">←</span>
+                <span>Back to Home</span>
+            </a>
+            <a href="index.html" class="inline-flex items-center gap-1 text-[#2f4b7c] hover:text-[#003f5c] transition-colors">
+                <span>Browse All Articles</span>
+                <span aria-hidden="true">→</span>
+            </a>
+        </nav>
+
+        <header class="text-center mb-16">
+            <p class="uppercase tracking-[0.3em] text-xs text-[#a05195] mb-4">AI Product Design</p>
+            <h1 class="text-4xl md:text-6xl font-black text-[#003f5c] mb-2">The Anatomy of an AI-Powered Nudge Engine</h1>
+            <p class="text-lg md:text-xl text-[#665191]">Crafting Hyper-Personalized Notifications for a Social Dining App</p>
+        </header>
+        
+        <section id="objective" class="mb-20 text-center">
+            <h2 class="text-3xl font-bold text-[#003f5c] mb-4">The Challenge: Cutting Through the Noise</h2>
+            <p class="max-w-3xl mx-auto text-lg mb-8">Standard notifications fail to engage users. The goal is to leverage AI to deliver social proof-driven, scarcity-based, and personalized nudges that adapt to each user's journey, transforming notifications from interruptions into valuable opportunities for connection.</p>
+            <div class="bg-white rounded-lg shadow-lg p-8 inline-block">
+                <div class="kpi-stat">+45%</div>
+                <div class="text-xl font-semibold text-[#a05195]">Projected Uplift in RSVP Conversion</div>
+                <p class="text-sm text-gray-500 mt-1">with Hyper-Personalized Nudges</p>
+            </div>
+        </section>
+
+        <section id="vectorization" class="mb-20">
+            <h2 class="text-3xl font-bold text-center text-[#003f5c] mb-12">Vectorization &amp; Attributes: The AI's Ingredients</h2>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                <div class="bg-white p-6 rounded-lg shadow-md">
+                    <h3 class="text-2xl font-bold mb-4 text-[#d45087] flex items-center">👤 User Attributes</h3>
+                    <p class="mb-4 text-gray-600">These attributes form a deep understanding of the user's social and dining preferences, creating a rich vector for matching.</p>
+                    <ul class="list-none space-y-2">
+                        <li class="flex items-center"><span class="text-[#ff7c43] mr-2">●</span> Interests &amp; Cuisine Preferences</li>
+                        <li class="flex items-center"><span class="text-[#ff7c43] mr-2">●</span> RSVP &amp; Attendance History</li>
+                        <li class="flex items-center"><span class="text-[#ff7c43] mr-2">●</span> Social Graph &amp; Friend Activity</li>
+                        <li class="flex items-center"><span class="text-[#ff7c43] mr-2">●</span> Engagement (clicks, views, shares)</li>
+                        <li class="flex items-center"><span class="text-[#ff7c43] mr-2">●</span> Typical Time Availability</li>
+                    </ul>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow-md">
+                    <h3 class="text-2xl font-bold mb-4 text-[#f95d6a] flex items-center">🗓️ Event Attributes</h3>
+                    <p class="mb-4 text-gray-600">Event vectors capture the essence and social context, allowing for nuanced matching beyond simple tags.</p>
+                    <ul class="list-none space-y-2">
+                        <li class="flex items-center"><span class="text-[#ffa600] mr-2">●</span> Theme, Cuisine &amp; Exclusivity</li>
+                        <li class="flex items-center"><span class="text-[#ffa600] mr-2">●</span> Popularity (RSVP velocity)</li>
+                        <li class="flex items-center"><span class="text-[#ffa600] mr-2">●</span> Host Credibility &amp; Reviews</li>
+                        <li class="flex items-center"><span class="text-[#ffa600] mr-2">●</span> Social Proof (Friends Attending)</li>
+                        <li class="flex items-center"><span class="text-[#ffa600] mr-2">●</span> Scarcity (Limited Spots)</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="triggers" class="mb-20">
+            <h2 class="text-3xl font-bold text-center text-[#003f5c] mb-12">Adaptive Nudges Across the User Journey</h2>
+            <div class="relative w-full overflow-x-auto">
+                <div class="flex items-stretch justify-between min-w-[800px] md:min-w-full">
+                    <div class="w-1/4 text-center p-2">
+                        <div class="bg-[#d45087] text-white py-2 px-4 rounded-full font-bold mb-3">1. Onboarding</div>
+                        <div class="bg-white rounded-lg shadow-md p-4 h-full">
+                            <h4 class="font-semibold text-[#d45087]">Trigger: Sign-up</h4>
+                            <p class="text-sm text-gray-600">"Welcome! Here are 3 dinner parties happening this week your friends might like."</p>
+                        </div>
+                    </div>
+                    <div class="flex items-center justify-center w-auto px-2"><div class="w-8 h-1 bg-[#a05195] rounded-full"></div></div>
+                    <div class="w-1/4 text-center p-2">
+                        <div class="bg-[#a05195] text-white py-2 px-4 rounded-full font-bold mb-3">2. Engagement</div>
+                        <div class="bg-white rounded-lg shadow-md p-4 h-full">
+                            <h4 class="font-semibold text-[#a05195]">Trigger: New Event</h4>
+                            <p class="text-sm text-gray-600">"Only 3 spots left at the 'Taco Tuesday' your friend John is attending!"</p>
+                        </div>
+                    </div>
+                    <div class="flex items-center justify-center w-auto px-2"><div class="w-8 h-1 bg-[#665191] rounded-full"></div></div>
+                    <div class="w-1/4 text-center p-2">
+                        <div class="bg-[#665191] text-white py-2 px-4 rounded-full font-bold mb-3">3. Post-Event</div>
+                        <div class="bg-white rounded-lg shadow-md p-4 h-full">
+                            <h4 class="font-semibold text-[#665191]">Trigger: Attendance</h4>
+                            <p class="text-sm text-gray-600">"How was the pizza night? Here's another event from the same host."</p>
+                        </div>
+                    </div>
+                    <div class="flex items-center justify-center w-auto px-2"><div class="w-8 h-1 bg-[#2f4b7c] rounded-full"></div></div>
+                    <div class="w-1/4 text-center p-2">
+                        <div class="bg-[#2f4b7c] text-white py-2 px-4 rounded-full font-bold mb-3">4. Re-engagement</div>
+                        <div class="bg-white rounded-lg shadow-md p-4 h-full">
+                            <h4 class="font-semibold text-[#2f4b7c]">Trigger: Dormancy</h4>
+                            <p class="text-sm text-gray-600">"We miss you! 5 of your friends joined events last week. See what's new."</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="architecture" class="mb-20">
+            <h2 class="text-3xl font-bold text-center text-[#003f5c] mb-12">Real-Time Personalization Architecture on AWS</h2>
+            <div class="bg-white p-8 rounded-lg shadow-lg w-full">
+                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 items-center text-center">
+                    <div class="p-4 bg-blue-50 border-2 border-dashed border-[#665191] rounded-lg">
+                        <h4 class="font-bold text-[#665191]">1. Trigger Event</h4>
+                        <p class="text-sm">(e.g., User Login, New Event)</p>
+                    </div>
+                    <div class="flex justify-center items-center">
+                        <span class="text-3xl text-[#665191] hidden md:block">→</span>
+                        <span class="text-3xl text-[#665191] md:hidden">↓</span>
+                    </div>
+                    <div class="p-4 bg-purple-50 border-2 border-dashed border-[#a05195] rounded-lg">
+                        <h4 class="font-bold text-[#a05195]">2. AWS Lambda</h4>
+                        <p class="text-sm">Initiates RAG Workflow</p>
+                    </div>
+                </div>
+                <div class="flex justify-center my-4">
+                    <div class="w-px h-8 bg-[#a05195] md:hidden"></div>
+                </div>
+                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 items-center text-center my-4 md:my-0">
+                    <div class="md:col-span-3 flex justify-center text-3xl text-[#a05195]">↓</div>
+                </div>
+                <div class="p-6 bg-gray-50 border-2 border-gray-300 rounded-lg text-center">
+                    <h4 class="font-bold text-lg text-[#003f5c] mb-4">3. Retrieval-Augmented Generation (RAG) Process</h4>
+                    <div class="flex flex-col md:flex-row items-center justify-around space-y-4 md:space-y-0">
+                        <div class="flex flex-col items-center">
+                           <div class="p-3 bg-orange-100 border-2 border-dashed border-[#ff7c43] rounded-lg w-48">
+                                <h5 class="font-semibold text-[#ff7c43]">Retrieve Context</h5>
+                                <p class="text-xs">Fetch user/event vectors from MongoDB Atlas</p>
+                            </div>
+                        </div>
+                        <div class="flow-line-vertical h-6 md:hidden"></div>
+                        <div class="hidden md:flex flow-line w-16"></div>
+                        <div class="flex flex-col items-center">
+                           <div class="p-3 bg-red-100 border-2 border-dashed border-[#f95d6a] rounded-lg w-48">
+                                <h5 class="font-semibold text-[#f95d6a]">OpenAI API Call</h5>
+                                <p class="text-xs">LLM drafts message with retrieved context</p>
+                            </div>
+                        </div>
+                        <div class="flow-line-vertical h-6 md:hidden"></div>
+                        <div class="hidden md:flex flow-line w-16"></div>
+                        <div class="flex flex-col items-center">
+                            <div class="p-3 bg-pink-100 border-2 border-dashed border-[#d45087] rounded-lg w-48">
+                                <h5 class="font-semibold text-[#d45087]">LLM Pre-Send Review</h5>
+                                <p class="text-xs">Agent checks for tone, accuracy, and spam risk</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 items-center text-center my-4 md:my-0">
+                     <div class="md:col-span-3 flex justify-center text-3xl text-[#003f5c]">↓</div>
+                </div>
+                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 items-center text-center">
+                     <div class="p-4 bg-teal-50 border-2 border-dashed border-teal-500 rounded-lg">
+                        <h4 class="font-bold text-teal-600">4. AWS SQS/SNS</h4>
+                        <p class="text-sm">Queue &amp; Distribute Message</p>
+                    </div>
+                     <div class="flex justify-center items-center">
+                        <span class="text-3xl text-teal-600 hidden md:block">→</span>
+                        <span class="text-3xl text-teal-600 md:hidden">↓</span>
+                    </div>
+                    <div class="p-4 bg-green-50 border-2 border-dashed border-green-500 rounded-lg">
+                        <h4 class="font-bold text-green-600">5. AWS Pinpoint</h4>
+                        <p class="text-sm">Deliver via Push, SMS, Email</p>
+                    </div>
+                 </div>
+            </div>
+        </section>
+
+        <section id="personalization-depth" class="mb-20">
+            <h2 class="text-3xl font-bold text-center text-[#003f5c] mb-12">The Personalization Spectrum</h2>
+            <p class="max-w-3xl mx-auto text-lg text-center mb-8">As user data deepens, the system transitions from rule-based fallbacks to sophisticated, LLM-crafted messages, ensuring relevance at every stage of the user's engagement.</p>
+            <div class="bg-white p-6 rounded-lg shadow-md">
+                <div class="chart-container h-96 md:h-[450px] max-h-[500px]">
+                    <canvas id="personalizationChart"></canvas>
+                </div>
+            </div>
+        </section>
+
+        <section id="measurement" class="mb-16">
+            <h2 class="text-3xl font-bold text-center text-[#003f5c] mb-12">Measuring Success: Key Performance Indicators</h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div class="bg-white p-6 rounded-lg shadow-md text-center">
+                    <h3 class="text-xl font-bold text-[#f95d6a] mb-2">Click-Through Rate</h3>
+                    <div class="chart-container !h-48 !max-h-48">
+                        <canvas id="ctrChart"></canvas>
+                    </div>
+                    <p class="mt-4 text-gray-600">Measures immediate notification relevance and appeal.</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow-md text-center">
+                    <h3 class="text-xl font-bold text-[#ff7c43] mb-2">RSVP Conversion</h3>
+                    <div class="chart-container !h-48 !max-h-48">
+                        <canvas id="rsvpChart"></canvas>
+                    </div>
+                    <p class="mt-4 text-gray-600">Tracks how effectively nudges drive core actions.</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow-md text-center">
+                    <h3 class="text-xl font-bold text-[#ffa600] mb-2">Profile Completion</h3>
+                    <div class="chart-container !h-48 !max-h-48">
+                        <canvas id="profileChart"></canvas>
+                    </div>
+                    <p class="mt-4 text-gray-600">Gauges success of gamified nudges to enrich user data.</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow-md text-center">
+                    <h3 class="text-xl font-bold text-[#d45087] mb-2">User Retention</h3>
+                    <div class="chart-container !h-48 !max-h-48">
+                        <canvas id="retentionChart"></canvas>
+                    </div>
+                    <p class="mt-4 text-gray-600">The ultimate measure of long-term platform value.</p>
+                </div>
+            </div>
+        </section>
+
+        <footer class="text-center mt-16 pt-8 border-t border-gray-300">
+            <p class="text-gray-500">This infographic illustrates a proposed system design for an AI-driven notification engine.</p>
+        </footer>
+    </div>
+
+    <script>
+        const wrapLabel = (label, maxLength = 16) => {
+            if (label.length <= maxLength) {
+                return label;
+            }
+            const words = label.split(' ');
+            const lines = [];
+            let currentLine = '';
+            for (const word of words) {
+                if ((currentLine + ' ' + word).trim().length > maxLength) {
+                    lines.push(currentLine.trim());
+                    currentLine = word;
+                } else {
+                    currentLine = (currentLine + ' ' + word).trim();
+                }
+            }
+            if (currentLine) {
+                lines.push(currentLine.trim());
+            }
+            return lines;
+        };
+
+        const defaultTooltipCallback = {
+            plugins: {
+                tooltip: {
+                    callbacks: {
+                        title: function(tooltipItems) {
+                            const item = tooltipItems[0];
+                            let label = item.chart.data.labels[item.dataIndex];
+                            if (Array.isArray(label)) {
+                              return label.join(' ');
+                            }
+                            return label;
+                        }
+                    }
+                },
+                legend: {
+                    position: 'bottom',
+                }
+            }
+        };
+
+        const personalizationData = {
+            labels: ['New User (0-24hr)', 'Low Data User (1-3 days)', 'Medium Data User (3-14 days)', 'High Data User (>14 days)'].map(l => wrapLabel(l)),
+            datasets: [
+                {
+                    label: 'Generic / Fallback',
+                    data: [80, 40, 10, 5],
+                    backgroundColor: '#003f5c',
+                },
+                {
+                    label: 'Segment-based',
+                    data: [20, 40, 30, 15],
+                    backgroundColor: '#665191',
+                },
+                {
+                    label: 'Vector Search Match',
+                    data: [0, 20, 50, 40],
+                    backgroundColor: '#d45087',
+                },
+                {
+                    label: 'LLM-Crafted (RAG)',
+                    data: [0, 0, 10, 40],
+                    backgroundColor: '#ff7c43',
+                }
+            ]
+        };
+        new Chart(document.getElementById('personalizationChart'), {
+            type: 'bar',
+            data: personalizationData,
+            options: {
+                ...defaultTooltipCallback,
+                maintainAspectRatio: false,
+                responsive: true,
+                scales: {
+                    x: { stacked: true },
+                    y: { stacked: true, beginAtZero: true, max: 100 }
+                },
+                plugins: {
+                    ...defaultTooltipCallback.plugins,
+                    title: {
+                        display: true,
+                        text: 'Notification Type by User Data Depth (%)',
+                        padding: { top: 10, bottom: 20 },
+                        font: { size: 16, weight: 'bold' }
+                    }
+                }
+            }
+        });
+
+        const createKpiChart = (canvasId, data, color, target) => {
+            new Chart(document.getElementById(canvasId), {
+                type: 'doughnut',
+                data: {
+                    labels: ['Achieved', 'Target'],
+                    datasets: [{
+                        data: [data, 100 - data],
+                        backgroundColor: [color, '#e9ecef'],
+                        borderColor: '#ffffff',
+                        borderWidth: 2,
+                        circumference: 180,
+                        rotation: 270,
+                    }]
+                },
+                options: {
+                    maintainAspectRatio: false,
+                    responsive: true,
+                    cutout: '70%',
+                    plugins: {
+                        tooltip: { enabled: false },
+                        legend: { display: false },
+                        title: {
+                            display: true,
+                            text: `${data}%`,
+                            position: 'bottom',
+                            y: -20,
+                            font: { size: 24, weight: 'bold', family: "'Inter', sans-serif" },
+                            color: color
+                        }
+                    }
+                }
+            });
+        };
+
+        createKpiChart('ctrChart', 12, '#f95d6a');
+        createKpiChart('rsvpChart', 8, '#ff7c43');
+        createKpiChart('profileChart', 65, '#ffa600');
+        createKpiChart('retentionChart', 25, '#d45087');
+    </script>
+</body>
+</html>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -92,23 +92,23 @@
                 <div class="max-w-4xl mx-auto">
                     <div class="blog-card p-8 rounded-2xl">
                         <div class="flex items-center space-x-2 mb-4">
-                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Operations</span>
-                            <span class="text-xs text-gray-500">February 21, 2025</span>
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Product Design</span>
+                            <span class="text-xs text-gray-500">February 25, 2025</span>
                         </div>
                         <h3 class="text-2xl md:text-3xl font-bold mb-4">
-                            <a href="building-va-in-the-loop-system.html" class="hover:text-indigo-400 transition-colors">
-                                Building a VA-in-the-Loop System with AI Checklists
+                            <a href="ai-powered-nudge-engine-for-social-dining.html" class="hover:text-indigo-400 transition-colors">
+                                The Anatomy of an AI-Powered Nudge Engine for Social Dining
                             </a>
                         </h3>
                         <p class="text-gray-300 mb-6 leading-relaxed">
-                            How I orchestrate publishing, offer creation, and media intelligence loops so virtual assistants and AI agents keep shipping assets every single week.
+                            A visual breakdown of the data model, personalization journey, and AWS services orchestrating hyper-personalized nudges that lift RSVP conversions.
                         </p>
                         <div class="flex items-center justify-between">
                             <div class="flex items-center space-x-4 text-sm text-gray-400">
-                                <span>📚 9 min read</span>
-                                <span>🔁 Systems Playbook</span>
+                                <span>📚 8 min read</span>
+                                <span>🧠 Personalization Playbook</span>
                             </div>
-                            <a href="building-va-in-the-loop-system.html" class="text-indigo-400 hover:text-indigo-300 font-semibold">
+                            <a href="ai-powered-nudge-engine-for-social-dining.html" class="text-indigo-400 hover:text-indigo-300 font-semibold">
                                 Read Full Post →
                             </a>
                         </div>
@@ -203,6 +203,26 @@
                     <!-- Post 1 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Product Design</span>
+                            <span class="text-xs text-gray-500">Feb 25, 2025</span>
+                        </div>
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="ai-powered-nudge-engine-for-social-dining.html" class="hover:text-indigo-400 transition-colors">
+                                The Anatomy of an AI-Powered Nudge Engine for Social Dining
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            How vector search, RAG messaging, and AWS services combine to ship hyper-relevant nudges that boost RSVP velocity.
+                        </p>
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-500">📚 8 min read</span>
+                            <a href="ai-powered-nudge-engine-for-social-dining.html" class="text-indigo-400 hover:underline">Read →</a>
+                        </div>
+                    </article>
+
+                    <!-- Post 2 -->
+                    <article class="blog-card p-6 rounded-xl">
+                        <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Operations</span>
                             <span class="text-xs text-gray-500">Feb 21, 2025</span>
                         </div>
@@ -220,7 +240,7 @@
                         </div>
                     </article>
 
-                    <!-- Post 2 -->
+                    <!-- Post 3 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Productivity Systems</span>
@@ -240,7 +260,7 @@
                         </div>
                     </article>
 
-                    <!-- Post 3 -->
+                    <!-- Post 4 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Integration</span>
@@ -260,7 +280,7 @@
                         </div>
                     </article>
 
-                    <!-- Post 4 -->
+                    <!-- Post 5 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Empire Building</span>
@@ -280,7 +300,7 @@
                         </div>
                     </article>
 
-                    <!-- Post 5 -->
+                    <!-- Post 6 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Productivity</span>
@@ -300,7 +320,7 @@
                         </div>
                     </article>
 
-                    <!-- Post 6 -->
+                    <!-- Post 7 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">LifeOS</span>
@@ -320,7 +340,7 @@
                         </div>
                     </article>
 
-                    <!-- Post 7 -->
+                    <!-- Post 8 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Global</span>
@@ -340,7 +360,7 @@
                         </div>
                     </article>
 
-                    <!-- Post 8 -->
+                    <!-- Post 9 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Consulting</span>

--- a/index.html
+++ b/index.html
@@ -361,14 +361,14 @@
             <div class="writing-grid">
                 <article class="writing-card">
                     <div class="writing-meta">
-                        <span class="writing-category">AI Operations</span>
-                        <span class="writing-date">February 21, 2025</span>
+                        <span class="writing-category">AI Product Design</span>
+                        <span class="writing-date">February 25, 2025</span>
                     </div>
-                    <h3 class="writing-title">Building a VA-in-the-Loop System with AI Checklists</h3>
+                    <h3 class="writing-title">Designing an AI-Powered Nudge Engine for Social Dining</h3>
                     <p class="writing-excerpt">
-                        The exact publishing, offer, and media loops I use to synchronize virtual assistants and AI agents so every week ships content, refreshed listings, and reader-ready insights.
+                        Breaking down the vector strategy, personalization logic, and AWS infrastructure powering high-converting social dining notifications.
                     </p>
-                    <a href="blogs/building-va-in-the-loop-system.html" class="writing-link">Read Featured Post →</a>
+                    <a href="blogs/ai-powered-nudge-engine-for-social-dining.html" class="writing-link">Read Latest Post →</a>
                 </article>
                 <article class="writing-card">
                     <div class="writing-meta">


### PR DESCRIPTION
## Summary
- add an infographic-style blog post covering the AI-powered nudge engine architecture and KPIs
- feature the new article across the blog hub, including the featured post and latest list
- update the home page writing section to link directly to the new nudge engine article

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68c8b9415c888325907486ce665de53c