### PR TITLE
Align VA loop blog with OfferUp and Otter.AI checklists

### DIFF
--- a/blogs/building-va-in-the-loop-system.html
+++ b/blogs/building-va-in-the-loop-system.html
@@ -4,17 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Building a VA-in-the-Loop System with AI Checklists - Chris Cruz</title>
-    <meta name="description" content="Design a VA-in-the-loop system that keeps content, offers, and media in sync. Learn the three operating checklists I use to keep assistants, AI agents, and platforms aligned."/>
-    <meta name="keywords" content="virtual assistant systems, AI workflows, VA in the loop, content distribution checklist, offer creation checklist, media transcription workflow, Chris Cruz"/>
+    <meta name="description" content="Design a VA-in-the-loop system that keeps content, OfferUp listings, and media intelligence in sync. Learn the three operating checklists I use to keep assistants, AI agents, and platforms aligned."/>
+    <meta name="keywords" content="virtual assistant systems, AI workflows, VA in the loop, content distribution checklist, OfferUp listing checklist, Otter.AI transcript workflow, Chris Cruz"/>
     <meta name="author" content="Chris Cruz"/>
     <meta property="og:title" content="Building a VA-in-the-Loop System with AI Checklists"/>
-    <meta property="og:description" content="A tactical playbook for turning virtual assistants and AI agents into a synchronized publishing, offer, and media machine."/>
+    <meta property="og:description" content="A tactical playbook for turning virtual assistants and AI agents into a synchronized publishing, OfferUp, and Otter.AI media machine."/>
     <meta property="og:type" content="article"/>
     <meta property="og:url" content="https://chriscruz.ai/blogs/building-va-in-the-loop-system.html"/>
     <meta property="og:image" content="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80"/>
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:title" content="Building a VA-in-the-Loop System with AI Checklists"/>
-    <meta name="twitter:description" content="A tactical playbook for turning virtual assistants and AI agents into a synchronized publishing, offer, and media machine."/>
+    <meta name="twitter:description" content="A tactical playbook for turning virtual assistants and AI agents into a synchronized publishing, OfferUp, and Otter.AI media machine."/>
     <meta name="twitter:image" content="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80"/>
     <link rel="stylesheet" href="../styles/main.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -82,21 +82,21 @@
                 <li><a href="#why-va-loop">Why a VA-in-the-Loop System Matters</a></li>
                 <li><a href="#architecture">The Three-Loop Architecture</a></li>
                 <li><a href="#loop-one">Loop One: Publishing Engine</a></li>
-                <li><a href="#loop-two">Loop Two: Offer Engine</a></li>
-                <li><a href="#loop-three">Loop Three: Media Intelligence</a></li>
+                <li><a href="#loop-two">Loop Two: OfferUp Marketplace Loop</a></li>
+                <li><a href="#loop-three">Loop Three: Otter.AI Media Intelligence</a></li>
                 <li><a href="#cadence">Cadence, Tooling, and Metrics</a></li>
                 <li><a href="#next-actions">Next Actions for Your Team</a></li>
             </ul>
         </div>
 
         <div class="blog-content">
-            <p>Most virtual assistant programs fail for the same reason: they operate as a series of disconnected tasks. What you want instead is a <em>system</em>—an always-on workflow that keeps humans and AI in the loop together, using shared checklists, shared data, and shared accountability. The three checklists below are the backbone of my VA operations for content publishing, offer optimization, and media intelligence.</p>
+            <p>Most virtual assistant programs fail for the same reason: they operate as a series of disconnected tasks. What you want instead is a <em>system</em>—an always-on workflow that keeps humans and AI in the loop together, using shared checklists, shared data, and shared accountability. The three checklists below are the backbone of my VA operations for content publishing, OfferUp selling, and Otter.AI-powered media intelligence.</p>
 
             <div class="highlight-box">
                 <h3>🔁 The VA-in-the-Loop Formula</h3>
                 <p><strong>One North Star:</strong> ship meaningful outcomes every week.<br>
-                <strong>Three Loops:</strong> Publishing → Offers → Media intelligence.<br>
-                <strong>Shared Assets:</strong> Airtable for status, Gemini/GPT agents for refinement, Buffer/TweetDeck for distribution.<br>
+                <strong>Three Loops:</strong> Publishing → OfferUp Marketplace → Otter.AI media intelligence.<br>
+                <strong>Shared Assets:</strong> Airtable for status, Gemini/GPT agents for refinement, OfferUp + Google Drive for inventory, Otter.AI for transcripts.<br>
                 <strong>Human Role:</strong> Decision-making, escalation, and brand quality control.</p>
             </div>
 
@@ -108,12 +108,12 @@
             </blockquote>
 
             <h2 id="architecture">The Three-Loop Architecture</h2>
-            <p>The operating model is simple: map each checklist to a loop, define the handoffs, and automate the notifications. When the publishing loop fires, it automatically triggers the offer loop to refresh messaging, which then triggers the media loop to add transcripts and highlights to our Reader app.</p>
+            <p>The operating model is simple: map each checklist to a loop, define the handoffs, and automate the notifications. When the publishing loop fires, it automatically prompts the OfferUp loop to refresh active listings, which then nudges the Otter.AI loop to capture the week's conversations and convert transcripts into assets.</p>
 
             <div class="loop-diagram">
                 <div><strong>Loop 1 – Publishing Engine:</strong> Draft → Refine → SEO → Publish → Promote → Track analytics.</div>
-                <div><strong>Loop 2 – Offer Engine:</strong> Capture site photos → Enhance → Package offer → Upload → Respond to leads.</div>
-                <div><strong>Loop 3 – Media Intelligence:</strong> Collect transcriptions → Summarize → Tag → Distribute to Reader → Validate playback.</div>
+                <div><strong>Loop 2 – OfferUp Marketplace:</strong> Audit inventory → Capture fresh photos → Write listing → Post on OfferUp → Monitor responses.</div>
+                <div><strong>Loop 3 – Otter.AI Intelligence:</strong> Record sessions → Clean transcript → Summarize highlights → Convert into assets → Archive learnings.</div>
             </div>
 
             <p>The glue is Airtable. Each checklist lives on its own table with status columns for <span class="pill">To Prep</span><span class="pill">In Progress</span><span class="pill">Ready for Review</span><span class="pill">Shipped</span>. Zapier automations notify me in Slack whenever a loop needs founder review.</p>
@@ -151,64 +151,107 @@
                 <li>After publishing, log early performance in Airtable—impressions, clicks, reposts—and review weekly.</li>
             </ul>
 
-            <h2 id="loop-two">Loop Two: Offer Engine</h2>
-            <p>Once content is live, we pivot to monetization. The offer engine keeps our photos, descriptions, and responses sharp on Airbnb, Booking, or whichever platform is active.</p>
-
-            <h3>1. Capture & Refinement</h3>
-            <ul>
-                <li>Schedule quarterly photo shoots covering wide angles, detail highlights, and lifestyle moments.</li>
-                <li>Batch process shots in Gemini Image for color correction and clarity, exporting both web and print versions.</li>
-                <li>Curate the top five images and annotate why they convert—useful for onboarding new photographers.</li>
-            </ul>
-
-            <h3>2. Offer Creation</h3>
-            <ul>
-                <li>Draft a keyword-rich title (55 characters max) and a description focused on benefits, social proof, and urgency.</li>
-                <li>Tag each offer with location metadata for geo-targeting campaigns.</li>
-                <li>Upload media and copy to the listing platform with consistent pricing notes and upsell prompts.</li>
-            </ul>
-
-            <h3>3. Engagement & Messaging</h3>
-            <ul>
-                <li>Use a messaging agent to draft quick, personalized responses to inquiries, then have the VA humanize the tone.</li>
-                <li>Log inquiry type, response time, and conversion outcome in the Airtable CRM to spot friction faster.</li>
-            </ul>
-
-            <div class="callout">
-                <strong>Quality Rule:</strong> No automated response goes out without a human glance. Speed is vital, but voice drives bookings.
+            <div class="highlight-box">
+                <h3>Publishing Loop Checklist Snapshot</h3>
+                <ul>
+                    <li>Pull the draft, align on voice, and lock scope in Airtable.</li>
+                    <li>Run SEO updates, accessibility checks, and hero media refreshes.</li>
+                    <li>Publish everywhere with QA sweeps for links, CTAs, and UTMs.</li>
+                    <li>Schedule promotion assets and monitor analytics inside Airtable.</li>
+                </ul>
+                <p><a href="../publishing-engine-checklist.html">Open the full publishing checklist →</a></p>
             </div>
 
-            <h2 id="loop-three">Loop Three: Media Intelligence</h2>
-            <p>The third loop converts raw audio or video into digestible insights. It's how we make sure podcasts, meetings, and livestreams feed the audience flywheel.</p>
+            <h2 id="loop-two">Loop Two: OfferUp Marketplace Loop</h2>
+            <p>Once the content loop ships, we shift into product velocity. The OfferUp loop keeps inventory moving by packaging each item with fresh visuals, a persuasive story, and fast buyer follow-up.</p>
 
-            <h3>1. Input Processing</h3>
+            <h3>1. Prep & Photography</h3>
             <ul>
-                <li>Centralize all transcripts from meetings, podcasts, or media drops into a shared Google Drive folder.</li>
-                <li>Run a custom LLM agent to extract an executive summary, key takeaways, and quotable highlights.</li>
+                <li>Pull the next item from the Airtable resale backlog, confirm specs, and gather any accessories or documentation.</li>
+                <li>Stage the product on a neutral background, capture 6–8 shots (hero, detail, scale), and drop them into the shared Google Drive folder.</li>
+                <li>Run the top shots through Gemini Image or Lightroom quick presets to clean backgrounds and balance lighting.</li>
             </ul>
 
-            <h3>2. Structuring</h3>
+            <h3>2. Listing Build</h3>
             <ul>
-                <li>Format everything in Markdown with metadata tags for speaker, date, and topic. Consistency unlocks searchability.</li>
-                <li>Store both the raw transcription and refined summary in Airtable for long-term recall.</li>
+                <li>Research comparable OfferUp listings to validate pricing and note high-performing keywords.</li>
+                <li>Draft the title, condition notes, and description in a Google Doc template, then pass the copy through a GPT agent for clarity and tag suggestions.</li>
+                <li>Log serial numbers or proofs of purchase in Airtable so buyer questions can be answered instantly.</li>
             </ul>
 
-            <h3>3. Reader Integration</h3>
+            <h3>3. Post & Optimize</h3>
             <ul>
-                <li>Export the formatted notes as Markdown, sync them into the Reader app, and test playback to confirm the structure renders properly.</li>
-                <li>Flag standout quotes for repurposing in newsletters, keynote decks, and sales collateral.</li>
+                <li>Upload photos and copy to OfferUp, double-check category, condition, price, and shipping preferences before posting.</li>
+                <li>Cross-post to secondary marketplaces (Facebook Marketplace, Craigslist) if the Airtable workflow marks the item as high-value.</li>
+                <li>Save the published link back to Airtable and set reminders for 48-hour price or boost reviews.</li>
             </ul>
+
+            <h3>4. Buyer Follow-Up</h3>
+            <ul>
+                <li>Monitor OfferUp messages during business hours, using a canned-response bank to move conversations forward while keeping the tone human.</li>
+                <li>Screen buyers with safety questions (pickup location, payment method) and log scheduled meetups on the shared calendar.</li>
+                <li>Mark items as sold, archive the conversation screenshot, and note the final sale price to feed future pricing decisions.</li>
+            </ul>
+
+            <div class="highlight-box">
+                <h3>OfferUp Loop Checklist Snapshot</h3>
+                <ul>
+                    <li>Confirm item details and capture refreshed images.</li>
+                    <li>Validate pricing and polish the description template.</li>
+                    <li>Post to OfferUp, save the link, and schedule follow-ups.</li>
+                    <li>Track buyer conversations and close the loop in Airtable.</li>
+                </ul>
+                <p><a href="../offerup-loop-checklist.html">Open the full OfferUp marketplace checklist →</a></p>
+            </div>
+
+            <div class="callout">
+                <strong>Safety Rule:</strong> Two-person verification for meetup plans—one person schedules, another confirms the details before the hand-off.
+            </div>
+
+            <h2 id="loop-three">Loop Three: Otter.AI Media Intelligence</h2>
+            <p>The third loop uses Otter.AI to capture every meaningful conversation and convert it into searchable assets we can redeploy across channels.</p>
+
+            <h3>1. Capture & Sync</h3>
+            <ul>
+                <li>Record calls, podcasts, or live sessions directly in Otter.AI, assigning the correct workspace folder before the meeting starts.</li>
+                <li>Tag participants, topics, and campaigns inside Otter.AI so follow-up automations know where the transcript should land.</li>
+                <li>Export high-priority audio files to Google Drive in case the team needs to create reels or short-form clips later.</li>
+            </ul>
+
+            <h3>2. Clean & Convert</h3>
+            <ul>
+                <li>Review the Otter.AI transcript for speaker accuracy, jargon, and action items within 12 hours of capture.</li>
+                <li>Send the cleaned transcript to a GPT summarization agent for executive notes, quotable sound bites, and FAQs.</li>
+                <li>Drop highlights into Airtable with status tags for newsletter, social, and sales enablement assets.</li>
+            </ul>
+
+            <h3>3. Activation</h3>
+            <ul>
+                <li>Publish the summary and raw transcript to the knowledge base (Notion or Coda) with clear metadata and backlinks.</li>
+                <li>Create derivative assets—LinkedIn post drafts, blog outlines, or Loom scripts—using the Otter.AI highlights as source material.</li>
+                <li>Set a reminder to revisit the transcript after two weeks to capture performance metrics and feedback.</li>
+            </ul>
+
+            <div class="highlight-box">
+                <h3>Otter.AI Loop Checklist Snapshot</h3>
+                <ul>
+                    <li>Record and tag the session inside Otter.AI.</li>
+                    <li>Clean the transcript and generate summaries within 12 hours.</li>
+                    <li>Publish insights to the knowledge base and queue derivative assets.</li>
+                </ul>
+                <p><a href="../otter-loop-checklist.html">Open the full Otter.AI media checklist →</a></p>
+            </div>
 
             <h2 id="cadence">Cadence, Tooling, and Metrics</h2>
             <p>The loops run on a Monday-to-Friday heartbeat:</p>
             <ul>
                 <li><strong>Monday:</strong> Publishing loop kickoff, assign drafts, run refinement agents.</li>
-                <li><strong>Tuesday–Wednesday:</strong> Offer loop updates—fresh media, pricing adjustments, messaging review.</li>
-                <li><strong>Thursday:</strong> Media intelligence loop processes transcripts from the week.</li>
-                <li><strong>Friday:</strong> Metrics review—track time-to-publish, booking conversions, audience engagement.</li>
+                <li><strong>Tuesday–Wednesday:</strong> OfferUp loop updates—prep new inventory, refresh listings, respond to buyers.</li>
+                <li><strong>Thursday:</strong> Otter.AI loop processes transcripts, publishes summaries, and seeds derivative assets.</li>
+                <li><strong>Friday:</strong> Metrics review—track time-to-publish, OfferUp sales conversions, audience engagement.</li>
             </ul>
 
-            <p>Our tool stack stays lean: Airtable for orchestration, Notion for knowledge capture, Google Drive for assets, Zapier for nudges, and Slack for approvals. Each checklist lives as a template that new assistants can duplicate, ensuring continuity even as the team evolves.</p>
+            <p>Our tool stack stays lean: Airtable for orchestration, OfferUp and Otter.AI for execution, Notion for knowledge capture, Google Drive for assets, Zapier for nudges, and Slack for approvals. Each checklist lives as a template that new assistants can duplicate, ensuring continuity even as the team evolves.</p>
 
             <h2 id="next-actions">Next Actions for Your Team</h2>
             <ol>

--- a/offerup-loop-checklist.html
+++ b/offerup-loop-checklist.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OfferUp Marketplace Checklist - VA-in-the-Loop System</title>
+    <meta name="description" content="Detailed OfferUp listing checklist for virtual assistants working inside the VA-in-the-loop system."/>
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        body { background: var(--gray-50); }
+        .page-container { max-width: 960px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+        .back-link { display: inline-block; margin-bottom: 1.5rem; color: var(--gray-500); font-weight: 500; }
+        .page-header { margin-bottom: 2.5rem; }
+        .page-header h1 { font-size: 2.25rem; margin-bottom: 0.75rem; }
+        .page-header p { max-width: 760px; }
+        .checklist-card { background: var(--white); border-radius: var(--radius-xl); border: 1px solid var(--gray-200); box-shadow: var(--shadow-md); padding: 1.75rem; margin-bottom: 1.5rem; }
+        .phase-label { display: inline-block; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em; background: var(--gray-100); color: var(--gray-600); padding: 0.25rem 0.75rem; border-radius: 999px; margin-bottom: 0.75rem; }
+        .checklist-items { list-style: none; padding-left: 0; }
+        .checklist-items li { display: flex; align-items: flex-start; gap: 0.75rem; margin-bottom: 0.85rem; }
+        .checklist-items input[type="checkbox"] { margin-top: 0.2rem; accent-color: var(--primary); }
+        .callout { background: #fff7ed; border-left: 4px solid var(--accent); padding: 1.25rem 1.5rem; border-radius: var(--radius-lg); margin-top: 1rem; color: #7c2d12; }
+        .cta { margin-top: 3rem; text-align: center; }
+        .cta a { font-weight: 600; }
+        @media (max-width: 640px) {
+            .page-container { padding: 2rem 1rem 3rem; }
+            .page-header h1 { font-size: 1.9rem; }
+            .checklist-card { padding: 1.5rem; }
+        }
+    </style>
+</head>
+<body>
+    <div class="page-container">
+        <a class="back-link" href="blogs/building-va-in-the-loop-system.html">← Back to the VA-in-the-Loop Playbook</a>
+        <header class="page-header">
+            <h1>OfferUp Marketplace Checklist</h1>
+            <p>Use this flow every time a new item hits the resale backlog. It keeps OfferUp listings accurate, persuasive, and safe while giving founders a clean audit trail in Airtable.</p>
+        </header>
+
+        <section class="checklist-section">
+            <div class="checklist-card">
+                <span class="phase-label">Phase 1</span>
+                <h3>Inventory Prep</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Pull the next priority item from Airtable and confirm condition, accessories, and replacement value.</label></li>
+                    <li><label><input type="checkbox">Clean the product, remove stickers, and note any cosmetic blemishes that must be disclosed.</label></li>
+                    <li><label><input type="checkbox">Collect receipts, serial numbers, and box dimensions for shipping estimates.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 2</span>
+                <h3>Photo Capture & Editing</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Shoot 6–8 images (front, back, details, scale, packaging) on a neutral background in natural light.</label></li>
+                    <li><label><input type="checkbox">Upload the raw set to the shared Google Drive folder with the Airtable item ID.</label></li>
+                    <li><label><input type="checkbox">Polish the top shots in Gemini Image or Lightroom—remove distractions, level, and crop square for OfferUp.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 3</span>
+                <h3>Listing Build</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Research comparable OfferUp listings to validate price and find keywords buyers search for.</label></li>
+                    <li><label><input type="checkbox">Draft the title, condition notes, and description in the Google Doc template; send to GPT for tone and formatting suggestions.</label></li>
+                    <li><label><input type="checkbox">Capture shipping, pickup radius, and payment options in Airtable so the founder can approve quickly.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 4</span>
+                <h3>Publish & Cross-Post</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Upload optimized photos and copy to OfferUp, confirm category, condition, and price before hitting publish.</label></li>
+                    <li><label><input type="checkbox">Add shipping details or meet-up preferences, double-check safety guidelines, and save the live link back to Airtable.</label></li>
+                    <li><label><input type="checkbox">Cross-post to secondary marketplaces flagged in Airtable (Facebook Marketplace, Craigslist, eBay) when applicable.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 5</span>
+                <h3>Buyer Management & Closeout</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Monitor OfferUp messages twice daily, logging buyer intent and follow-up tasks directly in Airtable.</label></li>
+                    <li><label><input type="checkbox">Use the approved response bank to answer FAQs, confirm pickup logistics, and flag any safety concerns to the founder.</label></li>
+                    <li><label><input type="checkbox">Mark the item as sold, archive screenshots of the final conversation, and record sale price plus payment method.</label></li>
+                </ul>
+                <div class="callout"><strong>Safety Reminder:</strong> Always coordinate public meetup locations and ensure a second team member is aware of the hand-off plan.</div>
+            </div>
+        </section>
+
+        <div class="cta">
+            <p>Round out the VA loops with the <a href="publishing-engine-checklist.html">publishing checklist</a> and the <a href="otter-loop-checklist.html">Otter.AI media checklist</a>.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/otter-loop-checklist.html
+++ b/otter-loop-checklist.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Otter.AI Media Intelligence Checklist - VA-in-the-Loop System</title>
+    <meta name="description" content="Otter.AI workflow checklist for capturing, cleaning, and converting transcripts inside the VA-in-the-loop system."/>
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        body { background: var(--gray-50); }
+        .page-container { max-width: 960px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+        .back-link { display: inline-block; margin-bottom: 1.5rem; color: var(--gray-500); font-weight: 500; }
+        .page-header { margin-bottom: 2.5rem; }
+        .page-header h1 { font-size: 2.25rem; margin-bottom: 0.75rem; }
+        .page-header p { max-width: 760px; }
+        .checklist-card { background: var(--white); border-radius: var(--radius-xl); border: 1px solid var(--gray-200); box-shadow: var(--shadow-md); padding: 1.75rem; margin-bottom: 1.5rem; }
+        .phase-label { display: inline-block; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em; background: var(--gray-100); color: var(--gray-600); padding: 0.25rem 0.75rem; border-radius: 999px; margin-bottom: 0.75rem; }
+        .checklist-items { list-style: none; padding-left: 0; }
+        .checklist-items li { display: flex; align-items: flex-start; gap: 0.75rem; margin-bottom: 0.85rem; }
+        .checklist-items input[type="checkbox"] { margin-top: 0.2rem; accent-color: var(--primary); }
+        .highlight { background: #1f2933; color: var(--white); padding: 1.25rem 1.5rem; border-radius: var(--radius-lg); margin-top: 1rem; font-size: 0.95rem; }
+        .cta { margin-top: 3rem; text-align: center; }
+        .cta a { font-weight: 600; }
+        @media (max-width: 640px) {
+            .page-container { padding: 2rem 1rem 3rem; }
+            .page-header h1 { font-size: 1.9rem; }
+            .checklist-card { padding: 1.5rem; }
+        }
+    </style>
+</head>
+<body>
+    <div class="page-container">
+        <a class="back-link" href="blogs/building-va-in-the-loop-system.html">← Back to the VA-in-the-Loop Playbook</a>
+        <header class="page-header">
+            <h1>Otter.AI Media Intelligence Checklist</h1>
+            <p>Make every meeting, podcast, or livestream produce assets. This checklist turns Otter.AI transcripts into summaries, quotes, and campaign-ready deliverables.</p>
+        </header>
+
+        <section class="checklist-section">
+            <div class="checklist-card">
+                <span class="phase-label">Phase 1</span>
+                <h3>Pre-Meeting Setup</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Create an Otter.AI calendar entry or import the agenda so the assistant joins automatically.</label></li>
+                    <li><label><input type="checkbox">Confirm recording permissions with attendees and drop the Otter.AI shared link in the meeting invite.</label></li>
+                    <li><label><input type="checkbox">Assign tags for topic, project, and owner in Airtable so the transcript routes correctly after capture.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 2</span>
+                <h3>Capture & Sync</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Join the session via Otter.AI and verify live transcription quality within the first two minutes.</label></li>
+                    <li><label><input type="checkbox">Bookmark key moments in real time (questions, decisions, quotes) to speed up the post-call review.</label></li>
+                    <li><label><input type="checkbox">Export raw audio to the "Source Audio" Google Drive folder when video clips or reels will be produced.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 3</span>
+                <h3>Transcript Cleanup</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Within 12 hours, correct speaker labels, jargon, and timestamps inside Otter.AI.</label></li>
+                    <li><label><input type="checkbox">Highlight action items, blockers, and quotable insights using Otter.AI comments.</label></li>
+                    <li><label><input type="checkbox">Export the cleaned transcript to Google Docs or Markdown for archival.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 4</span>
+                <h3>Conversion & Publishing</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Send the transcript through a GPT summary agent to produce executive notes, newsletter bullets, and FAQ drafts.</label></li>
+                    <li><label><input type="checkbox">Publish the summary, highlights, and transcript link to Notion/Coda with backlinks to related projects.</label></li>
+                    <li><label><input type="checkbox">Create derivative tasks in Airtable for social posts, blog outlines, or sales enablement based on the highlights.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 5</span>
+                <h3>Follow-Up & Metrics</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Notify stakeholders in Slack with the summary link and top three takeaways.</label></li>
+                    <li><label><input type="checkbox">Log distribution performance (opens, clicks, reuse) inside Airtable after two weeks.</label></li>
+                    <li><label><input type="checkbox">Archive transcript assets with consistent naming conventions so future assistants can locate them fast.</label></li>
+                </ul>
+                <div class="highlight">Reminder: flag any sensitive topics in the summary handoff so human review happens before external reuse.</div>
+            </div>
+        </section>
+
+        <div class="cta">
+            <p>Need the other loops? Grab the <a href="publishing-engine-checklist.html">publishing checklist</a> and the <a href="offerup-loop-checklist.html">OfferUp checklist</a>.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/publishing-engine-checklist.html
+++ b/publishing-engine-checklist.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Publishing Engine Checklist - VA-in-the-Loop System</title>
+    <meta name="description" content="Step-by-step publishing checklist for virtual assistants running the VA-in-the-loop system."/>
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        body { background: var(--gray-50); }
+        .page-container { max-width: 960px; margin: 0 auto; padding: 2.5rem 1.5rem 4rem; }
+        .back-link { display: inline-block; margin-bottom: 1.5rem; color: var(--gray-500); font-weight: 500; }
+        .page-header { margin-bottom: 2.5rem; }
+        .page-header h1 { font-size: 2.25rem; margin-bottom: 0.75rem; }
+        .page-header p { max-width: 720px; }
+        .checklist-section { margin-bottom: 2rem; }
+        .checklist-card { background: var(--white); border-radius: var(--radius-xl); border: 1px solid var(--gray-200); box-shadow: var(--shadow-md); padding: 1.75rem; margin-bottom: 1.5rem; }
+        .phase-label { display: inline-block; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em; background: var(--gray-100); color: var(--gray-600); padding: 0.25rem 0.75rem; border-radius: 999px; margin-bottom: 0.75rem; }
+        .checklist-card h3 { margin-bottom: 1rem; }
+        .checklist-items { list-style: none; padding-left: 0; }
+        .checklist-items li { display: flex; align-items: flex-start; gap: 0.75rem; margin-bottom: 0.85rem; }
+        .checklist-items input[type="checkbox"] { margin-top: 0.2rem; accent-color: var(--primary); }
+        .pro-tip { background: var(--gray-900); color: var(--white); padding: 1.25rem 1.5rem; border-radius: var(--radius-lg); margin-top: 1rem; font-size: 0.95rem; }
+        .cta { margin-top: 3rem; text-align: center; }
+        .cta a { font-weight: 600; }
+        @media (max-width: 640px) {
+            .page-container { padding: 2rem 1rem 3rem; }
+            .page-header h1 { font-size: 1.9rem; }
+            .checklist-card { padding: 1.5rem; }
+        }
+    </style>
+</head>
+<body>
+    <div class="page-container">
+        <a class="back-link" href="blogs/building-va-in-the-loop-system.html">← Back to the VA-in-the-Loop Playbook</a>
+        <header class="page-header">
+            <h1>Publishing Engine Checklist</h1>
+            <p>This checklist keeps every article moving from draft to distribution without surprises. Duplicate it in Airtable, assign a VA owner, and run the loop every time a new story is ready.</p>
+        </header>
+
+        <section class="checklist-section">
+            <div class="checklist-card">
+                <span class="phase-label">Phase 1</span>
+                <h3>Plan & Draft Confirmation</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Pull the draft card from Airtable and confirm target publish date, channel mix, and reviewers.</label></li>
+                    <li><label><input type="checkbox">Review the outline for message-market fit, calling out updates needed before refinement.</label></li>
+                    <li><label><input type="checkbox">Capture the approved voice and tone guidelines inside the draft so agents work from a single source.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 2</span>
+                <h3>SEO & Editorial Polish</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Run the content through a GPT or Gemini editor for grammar, clarity, and call-to-action reinforcement.</label></li>
+                    <li><label><input type="checkbox">Generate the keyword plan, schema block, and meta description; capture them in the Airtable record.</label></li>
+                    <li><label><input type="checkbox">Update headings, internal links, and pull quotes to match the latest keyword and positioning decisions.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 3</span>
+                <h3>Media & Accessibility</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Refresh the hero image and supporting visuals, exporting both hi-res and lightweight versions.</label></li>
+                    <li><label><input type="checkbox">Write human-first alt text and captions so accessibility stays on-brand.</label></li>
+                    <li><label><input type="checkbox">Embed any embeds, charts, or downloads and verify they load on mobile preview.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 4</span>
+                <h3>Publish & QA</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Publish to the primary platform (Medium, site, or CMS) and confirm formatting on desktop and mobile.</label></li>
+                    <li><label><input type="checkbox">Push the Markdown or HTML update to GitHub with a changelog note for future audits.</label></li>
+                    <li><label><input type="checkbox">Complete the final QA sweep: working links, correct UTMs, CTA placement, and conversion pixels.</label></li>
+                </ul>
+            </div>
+
+            <div class="checklist-card">
+                <span class="phase-label">Phase 5</span>
+                <h3>Promotion & Measurement</h3>
+                <ul class="checklist-items">
+                    <li><label><input type="checkbox">Draft 3–5 social posts (Twitter/X, LinkedIn, newsletter blurb) and queue them in Buffer.</label></li>
+                    <li><label><input type="checkbox">Log the publish date, hero asset, and campaign tags in Airtable for analytics tracking.</label></li>
+                    <li><label><input type="checkbox">Set the review reminder to capture early performance metrics and feedback in the weekly report.</label></li>
+                </ul>
+                <div class="pro-tip">Pro tip: Capture Loom walkthroughs of every major publish to build a training library for future assistants.</div>
+            </div>
+        </section>
+
+        <div class="cta">
+            <p>Need the companion loops? <a href="offerup-loop-checklist.html">OfferUp marketplace checklist</a> · <a href="otter-loop-checklist.html">Otter.AI media checklist</a></p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update the VA-in-the-loop blog to describe the OfferUp marketplace loop and Otter.AI media intelligence while adding quick checklist callouts
- add dedicated publishing, OfferUp, and Otter.AI checklist pages and cross-link them from the article and from each other
- refresh cadence and tooling references so the three loops share the same operating context

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68c8bc15de408325b08a2a0e76261f6e