### PR TITLE
Expand latest writing grid with all blog posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,50 @@
             <div class="writing-grid">
                 <article class="writing-card">
                     <div class="writing-meta">
+                        <span class="writing-category">Operational Intelligence</span>
+                        <span class="writing-date">September 15, 2025</span>
+                    </div>
+                    <h3 class="writing-title">DDA Going Primary Dashboard Strategy</h3>
+                    <p class="writing-excerpt">
+                        Dashboards aren't just tools—they are the nerve center of DDA Going Primary, aligning leaders around the push to production readiness.
+                    </p>
+                    <a href="blogs/dda-going-primary-dashboard-strategy.html" class="writing-link">Read the Dashboard Strategy →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">AI Productivity</span>
+                        <span class="writing-date">September 14, 2025</span>
+                    </div>
+                    <h3 class="writing-title">AI Writing Revolution: The Complete Productivity Guide</h3>
+                    <p class="writing-excerpt">
+                        How artificial intelligence is transforming the writing process and boosting output by 40% across ideation, drafting, and editing.
+                    </p>
+                    <a href="blogs/ai-writing-revolution-productivity-guide.html" class="writing-link">Read the Guide →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">AI Architecture</span>
+                        <span class="writing-date">September 14, 2025</span>
+                    </div>
+                    <h3 class="writing-title">Smart Nudges: Implementation Deep Dive</h3>
+                    <p class="writing-excerpt">
+                        Behavioral psychology-driven notifications that convert never-engaged users into active participants through 23 specialized nudge types.
+                    </p>
+                    <a href="blogs/smart-nudges-implementation-deep-dive.html" class="writing-link">Explore the Nudge System →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">Startup Strategy</span>
+                        <span class="writing-date">September 14, 2025</span>
+                    </div>
+                    <h3 class="writing-title">Reddit Startup Idea Validation</h3>
+                    <p class="writing-excerpt">
+                        A systematic approach to surfacing validated startup ideas from Reddit and transforming them into Framer prototypes.
+                    </p>
+                    <a href="blogs/reddit-startup-idea-validation-framer-wireframing.html" class="writing-link">Validate with Reddit →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
                         <span class="writing-category">Quality Engineering</span>
                         <span class="writing-date">March 24, 2025</span>
                     </div>
@@ -377,22 +421,108 @@
                     </div>
                     <h3 class="writing-title">The ETD API: From Raw Data to Rich Experience</h3>
                     <p class="writing-excerpt">
-                        A deep dive into the event correlation, enrichment, and customer experience metrics behind our flagship
-                        ETD API case study.
+                        A deep dive into the event correlation, enrichment, and customer experience metrics behind our flagship ETD API case study.
                     </p>
                     <a href="blogs/etd-api-infographic-from-raw-data-to-rich-experience.html" class="writing-link">Read Case Study →</a>
                 </article>
                 <article class="writing-card">
                     <div class="writing-meta">
-                        <span class="writing-category">Entrepreneurship</span>
-                        <span class="writing-date">Coming Soon</span>
+                        <span class="writing-category">Backend Reliability</span>
+                        <span class="writing-date">March 16, 2025</span>
                     </div>
-                    <h3 class="writing-title">Scaling from 0 to 200: Lessons from Building Kirillate</h3>
+                    <h3 class="writing-title">Diagnosing the Cuculi Backend Slowdown</h3>
                     <p class="writing-excerpt">
-                        Key insights and hard-won lessons from scaling a startup from founding 
-                        to 200 employees with First Round Capital backing.
+                        Two minutes after the 1:30 PM push, response times tripled and socket listeners lagged—this is the triage plan to get the Hapi stack breathing again.
                     </p>
-                    <a href="/writing/scaling-startup-lessons" class="writing-link">Read More →</a>
+                    <a href="blogs/cuculi-backend-slowdown-diagnostic.html" class="writing-link">Review the Incident Plan →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">API Modernization</span>
+                        <span class="writing-date">March 12, 2025</span>
+                    </div>
+                    <h3 class="writing-title">DDA API Migration: V2 to V3</h3>
+                    <p class="writing-excerpt">
+                        An urgent roadmap for aggregators to eliminate thread-hanging failures, align with supported versions, and unlock new ETD capabilities.
+                    </p>
+                    <a href="blogs/dda-api-migration-v2-to-v3.html" class="writing-link">Plan the Migration →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">Fintech Education</span>
+                        <span class="writing-date">March 5, 2025</span>
+                    </div>
+                    <h3 class="writing-title">Designing the Debit Card Transaction Processing ETL Demo</h3>
+                    <p class="writing-excerpt">
+                        Go behind the scenes of the debit card sandbox that visualizes authorization, memo, and merchant enrichment in one interactive flow.
+                    </p>
+                    <a href="blogs/debit-card-transaction-processing-demo.html" class="writing-link">Walk Through the Demo →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">AI Product Design</span>
+                        <span class="writing-date">February 25, 2025</span>
+                    </div>
+                    <h3 class="writing-title">The Anatomy of an AI-Powered Nudge Engine</h3>
+                    <p class="writing-excerpt">
+                        How vector search, RAG messaging, and AWS services combine to ship hyper-relevant nudges that boost RSVP velocity.
+                    </p>
+                    <a href="blogs/ai-powered-nudge-engine-for-social-dining.html" class="writing-link">Design the Nudge Engine →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">AI Operations</span>
+                        <span class="writing-date">February 21, 2025</span>
+                    </div>
+                    <h3 class="writing-title">Building a VA-in-the-Loop System with AI Checklists</h3>
+                    <p class="writing-excerpt">
+                        The operating system I use to keep virtual assistants, AI agents, and distribution platforms shipping in sync every week.
+                    </p>
+                    <a href="blogs/building-va-in-the-loop-system.html" class="writing-link">Build the Loop →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">Productivity Systems</span>
+                        <span class="writing-date">February 18, 2025</span>
+                    </div>
+                    <h3 class="writing-title">Building the HTML Source Code Viewer in a Weekend</h3>
+                    <p class="writing-excerpt">
+                        Quick recap of the design decisions, fetch workflow, and clipboard tricks that made the new HTML Source Code Viewer feel fast and reliable.
+                    </p>
+                    <a href="blogs/html-source-viewer-build.html" class="writing-link">See the Build Notes →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">AI &amp; Team Management</span>
+                        <span class="writing-date">January 15, 2025</span>
+                    </div>
+                    <h3 class="writing-title">AI-Powered Virtual Assistant Management</h3>
+                    <p class="writing-excerpt">
+                        How I shifted my VA program from tracking hours to measuring value, pairing human judgment with AI amplification for maximum output.
+                    </p>
+                    <a href="blogs/ai-powered-virtual-assistant-management-framework-v2.html" class="writing-link">Optimize Your VA Program →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">Empire Building</span>
+                        <span class="writing-date">January 15, 2025</span>
+                    </div>
+                    <h3 class="writing-title">System Thinking: The Foundation of Every Great Empire</h3>
+                    <p class="writing-excerpt">
+                        LifeOS development reminded me that enduring empires are built on systems, not goals—here's how to design loops that compound over time.
+                    </p>
+                    <a href="blogs/system-thinking-empire-building.html" class="writing-link">Design Better Systems →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
+                        <span class="writing-category">AI Integration</span>
+                        <span class="writing-date">January 12, 2025</span>
+                    </div>
+                    <h3 class="writing-title">How AI is Predicting My Most Productive Hours</h3>
+                    <p class="writing-excerpt">
+                        LifeOS now forecasts my peak performance windows and auto-schedules deep work, proving AI is most powerful when it learns your patterns.
+                    </p>
+                    <a href="blogs/ai-productivity-enhancement.html" class="writing-link">Unlock Your Peak Hours →</a>
                 </article>
             </div>
             <div class="writing-cta">


### PR DESCRIPTION
## Summary
- expand the home page "Latest Writing" grid so every article in the `blogs/` folder appears with category, date, and excerpt
- surface September 2025 additions (dashboard strategy, AI writing, smart nudges, Reddit validation) alongside the earlier fintech and productivity posts
- remove the placeholder entry and ensure each card links to the corresponding HTML file under `blogs/`

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c9cedad418832588fa3b00be14ee11