### PR TITLE
Add CR enrichment incident playbook blog and index links

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -180,6 +180,24 @@
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                    <article class="blog-card p-6 rounded-xl">
+                        <div class="flex items-center space-x-2 mb-4">
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Incident Response</span>
+                            <span class="text-xs text-gray-500">Sep 19, 2025</span>
+                        </div>
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="troubleshooting-transaction-enrichment-api.html" class="hover:text-indigo-400 transition-colors">
+                                Restoring Transaction Enrichment in CR
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            Executive recap of the triage marathon that traced ETU nulls, repaired batch jobs, and codified conditioned data rituals ahead of the September readiness checkpoint.
+                        </p>
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-500">📚 10 min read</span>
+                            <a href="troubleshooting-transaction-enrichment-api.html" class="text-indigo-400 hover:underline">Read →</a>
+                        </div>
+                    </article>
                     <!-- Post -1 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">

--- a/blogs/troubleshooting-transaction-enrichment-api.html
+++ b/blogs/troubleshooting-transaction-enrichment-api.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Restoring Transaction Enrichment in CR: Incident Playbook | ChrisCruz.ai</title>
+    <meta name="description" content="Comprehensive recap of the triage effort that restored transaction enrichment in the CR environment, with executive summary, detailed breakdown, implementation guide, and reflection prompts for fintech leaders.">
+    <meta name="keywords" content="transaction enrichment, incident management, fintech operations, ETU, CDP, CR environment, partial content API">
+    <meta name="author" content="Christopher Manuel Cruz-Guzman">
+    <meta property="og:title" content="Restoring Transaction Enrichment in CR: Incident Playbook">
+    <meta property="og:description" content="From partial responses to full enrichment—how the team diagnosed ETU nulls, rebuilt test data integrity, and aligned cross-team rituals.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://chriscruz.ai/blogs/troubleshooting-transaction-enrichment-api.html">
+    <meta property="og:image" content="https://chriscruz.ai/images/transaction-enrichment-triage.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Restoring Transaction Enrichment in CR: Incident Playbook">
+    <meta name="twitter:description" content="Executive-ready breakdown of the CR enrichment outage, remediation steps, and ongoing risk controls.">
+    <meta name="article:published_time" content="2025-09-19T00:00:00Z">
+    <meta name="article:author" content="Christopher Manuel Cruz-Guzman">
+    <meta name="article:section" content="Incident Response">
+    <meta name="article:tag" content="fintech, incident management, merchant enrichment, quality engineering">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #050510;
+            color: #f8fafc;
+        }
+        .gradient-text {
+            background: linear-gradient(90deg, #6366f1, #ec4899, #f97316);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .blog-content {
+            background-color: rgba(15, 23, 42, 0.7);
+            border: 1px solid rgba(99, 102, 241, 0.25);
+            backdrop-filter: blur(18px);
+        }
+        .highlight-box {
+            background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(236, 72, 153, 0.16));
+            border: 1px solid rgba(129, 140, 248, 0.4);
+        }
+        .challenge-card {
+            background: linear-gradient(135deg, rgba(239, 68, 68, 0.18), rgba(249, 115, 22, 0.14));
+            border: 1px solid rgba(248, 113, 113, 0.45);
+        }
+        .framework-box {
+            background: linear-gradient(135deg, rgba(20, 184, 166, 0.16), rgba(59, 130, 246, 0.16));
+            border: 1px solid rgba(45, 212, 191, 0.4);
+        }
+        .example-box {
+            background: linear-gradient(135deg, rgba(168, 85, 247, 0.16), rgba(14, 165, 233, 0.18));
+            border: 1px solid rgba(165, 180, 252, 0.45);
+        }
+        .reflection-box {
+            background: linear-gradient(135deg, rgba(94, 234, 212, 0.14), rgba(34, 197, 94, 0.12));
+            border: 1px solid rgba(52, 211, 153, 0.45);
+        }
+        .anchor-link {
+            color: #a5b4fc;
+        }
+        .anchor-link:hover {
+            color: #f9a8d4;
+        }
+    </style>
+</head>
+<body class="antialiased">
+
+    <header class="fixed top-0 left-0 right-0 z-50 bg-black/40 backdrop-blur-md">
+        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../brand-hub.html" class="text-xl font-bold tracking-tighter">ChrisCruz<span class="text-indigo-400">.ai</span></a>
+            <nav class="hidden md:flex space-x-8 text-sm font-medium text-slate-200">
+                <a href="../brand-hub.html" class="hover:text-indigo-300 transition">Empire</a>
+                <a href="../manifesto.html" class="hover:text-indigo-300 transition">Manifesto</a>
+                <a href="../projects" class="hover:text-indigo-300 transition">Projects</a>
+                <a href="../contact.html" class="hover:text-indigo-300 transition">Contact</a>
+            </nav>
+            <span class="text-xs font-semibold py-1 px-3 rounded-full bg-indigo-400/15 text-indigo-200 border border-indigo-400/40">Incident Response</span>
+        </div>
+    </header>
+
+    <main class="pt-24">
+        <section class="py-20 px-6">
+            <div class="container mx-auto max-w-4xl">
+                <div class="text-center mb-10">
+                    <div class="flex items-center justify-center space-x-3 mb-4 text-xs text-slate-300">
+                        <span class="uppercase tracking-[0.3em] text-indigo-300">Transaction Enrichment</span>
+                        <span>•</span>
+                        <span>September 19, 2025</span>
+                        <span>•</span>
+                        <span>10 min read</span>
+                    </div>
+                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-black tracking-tight mb-6">
+                        Restoring the <span class="gradient-text">Transaction Enrichment Pipeline</span>
+                    </h1>
+                    <p class="text-lg text-slate-300 max-w-3xl mx-auto leading-relaxed">
+                        Three war-room sessions transformed partial API payloads in the CR environment into a repeatable incident playbook. This is the executive recap, the operating system for remediation, and the questions we still need to ask before the next sprint deadline.
+                    </p>
+                </div>
+                <div class="flex items-center justify-center space-x-4 text-sm text-slate-400">
+                    <div class="flex items-center space-x-2">
+                        <div class="w-10 h-10 bg-gradient-to-r from-indigo-500 to-pink-500 rounded-full flex items-center justify-center text-white font-bold">CC</div>
+                        <span>Christopher Manuel Cruz-Guzman</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="py-10 px-6">
+            <div class="container mx-auto max-w-3xl">
+                <div class="blog-content p-8 md:p-10 rounded-3xl space-y-12">
+                    <div class="highlight-box p-6 rounded-2xl">
+                        <h2 id="executive-summary" class="text-2xl font-bold text-white mb-4">Executive Summary</h2>
+                        <ul class="space-y-3 text-base text-slate-100 leading-relaxed">
+                            <li><strong>CR-only failure:</strong> Transaction enrichment dropped to HTTP 204/206 because ETU stopped populating <code>enrichedMerchantDetail_v3</code> after upstream payloads shipped without mandatory merchant geography.</li>
+                            <li><strong>Two root causes:</strong> A failed UAT SOD batch blocked posted transactions, and CDP test data omitted required fields for pending transactions, triggering valid enrichment rejections.</li>
+                            <li><strong>Recovery program:</strong> Manual batch reruns, conditioned data requests, and enhanced observability restored parity with Production and anchored new triage rituals ahead of the September 30 stability checkpoint.</li>
+                        </ul>
+                    </div>
+
+                    <div class="space-y-4">
+                        <h2 class="text-2xl font-bold text-indigo-200">In this Article</h2>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+                            <a href="#key-insights" class="anchor-link">Key Insights &amp; Signals</a>
+                            <a href="#detailed-breakdown" class="anchor-link">Detailed Breakdown by Meeting</a>
+                            <a href="#implementation-guide" class="anchor-link">Implementation Guide</a>
+                            <a href="#reflection-questions" class="anchor-link">Reflection Questions</a>
+                            <a href="#atomic-notes" class="anchor-link">Atomic Notes</a>
+                            <a href="#related-reading" class="anchor-link">Related Reading</a>
+                        </div>
+                    </div>
+
+                    <section id="key-insights" class="space-y-6">
+                        <h2 class="text-3xl font-bold text-white">Key Insights &amp; Signals</h2>
+                        <p class="text-base text-slate-200 leading-relaxed">The three sessions surfaced patterns that apply far beyond this incident. Use these insights as leading indicators the next time enrichment coverage slips.</p>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-5">
+                            <div class="highlight-box p-5 rounded-2xl">
+                                <h3 class="text-lg font-semibold text-white mb-2">Observe the Nulls</h3>
+                                <p class="text-sm text-slate-100 leading-relaxed">Adding <code>enrichedMerchantDetail_v3</code> to the Splunk dashboard made null payloads undeniable and accelerated the trace from ETU to CDP.</p>
+                            </div>
+                            <div class="challenge-card p-5 rounded-2xl">
+                                <h3 class="text-lg font-semibold text-white mb-2">Batch Jobs Bite Back</h3>
+                                <p class="text-sm text-slate-100 leading-relaxed">The UAT SOD job silently failed, deleting evidence until a manual rerun restored posted data. Batch reliability is now a gating item for go-live.</p>
+                            </div>
+                            <div class="framework-box p-5 rounded-2xl">
+                                <h3 class="text-lg font-semibold text-white mb-2">Data Conditioning is Product Work</h3>
+                                <p class="text-sm text-slate-100 leading-relaxed">Every pending transaction must ship with city, state, and zip. Conditioning is now a CDP OKR, not a courtesy.</p>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section id="detailed-breakdown" class="space-y-10">
+                        <h2 class="text-3xl font-bold text-white">Detailed Breakdown</h2>
+                        <p class="text-base text-slate-200 leading-relaxed">Each meeting compounded our understanding. Together they form the timeline for any retro or audit.</p>
+
+                        <article class="space-y-4">
+                            <h3 class="text-2xl font-semibold text-indigo-200">Meeting 1 — Instrument the Gap</h3>
+                            <p class="text-base text-slate-200 leading-relaxed">We confirmed a CR-specific defect: production payloads looked healthy, but CR calls returned partial or empty data. Dan Robinson's multi-source dashboard traced trace IDs across TPS, ETU, and Splunk, exposing null <code>enrichedMerchantDetail_v3</code> payloads for both pending and posted states.</p>
+                            <div class="example-box p-5 rounded-2xl">
+                                <h4 class="text-lg font-semibold text-white mb-2">Diagnostic Flow</h4>
+                                <ol class="list-decimal list-inside text-sm text-slate-100 space-y-1">
+                                    <li>Compare Prod vs. CR responses using Chris Cruz's golden JSON.</li>
+                                    <li>Query the dashboard with the failing trace ID to locate ETU events.</li>
+                                    <li>Validate pending vs. posted status to understand enrichment pathways.</li>
+                                </ol>
+                                <p class="text-sm text-slate-100 mt-3 leading-relaxed">Outcome: Hypothesis that ETU ingested a null payload was confirmed, triggering requests for fresh pending data and instrumentation upgrades.</p>
+                            </div>
+                            <div class="challenge-card p-5 rounded-2xl">
+                                <h4 class="text-lg font-semibold text-white mb-2">Immediate Challenges</h4>
+                                <ul class="list-disc list-inside text-sm text-slate-100 space-y-2">
+                                    <li>Pending transactions decay into posted records within days, shrinking the test window.</li>
+                                    <li>Null enrichment data masked downstream logic, giving false positives in automation suites.</li>
+                                    <li>CR environment instability made root-cause isolation slower than Prod.</li>
+                                </ul>
+                            </div>
+                        </article>
+
+                        <article class="space-y-4">
+                            <h3 class="text-2xl font-semibold text-indigo-200">Meeting 2 — Fix the Feeds</h3>
+                            <p class="text-base text-slate-200 leading-relaxed">With the enriched fields still dark, Jacob (Columbus) uncovered a failed SOD batch that halted posted enrichment, while Ajay traced an incomplete CDP payload for pending flows.</p>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                                <div class="highlight-box p-5 rounded-2xl">
+                                    <h4 class="text-lg font-semibold text-white mb-2">Posted Transactions</h4>
+                                    <ul class="list-disc list-inside text-sm text-slate-100 space-y-1">
+                                        <li>SOD batch crashed in UAT; no enrichment records propagated.</li>
+                                        <li>Manual rerun restored merchant metadata but dropped some historical activity, now a BLR ticket.</li>
+                                        <li>New monitoring added to confirm batch completion before QA sign-off.</li>
+                                    </ul>
+                                </div>
+                                <div class="highlight-box p-5 rounded-2xl">
+                                    <h4 class="text-lg font-semibold text-white mb-2">Pending Transactions</h4>
+                                    <ul class="list-disc list-inside text-sm text-slate-100 space-y-1">
+                                        <li>CDP payload arrived without <em>merchantState</em>, failing enrichment validation.</li>
+                                        <li>Transactions with full address data enriched successfully, proving service health.</li>
+                                        <li>Action: Kwame to ship conditioned data sets with city, state, and zip.</li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <div class="framework-box p-6 rounded-2xl">
+                                <h4 class="text-lg font-semibold text-white mb-3">Two-Track Recovery Framework</h4>
+                                <div class="space-y-2 text-sm text-slate-100 leading-relaxed">
+                                    <p><strong>Track 1 — Batch Integrity:</strong> Monitor scheduled jobs, store completion evidence, and keep rollback scripts ready for reruns.</p>
+                                    <p><strong>Track 2 — Payload Conditioning:</strong> Validate upstream schemas before QA, with automated checks for mandatory fields across pending/posting states.</p>
+                                    <p class="text-slate-200">This framework now complements our <a href="strategic-transaction-history-architecture.html" class="anchor-link underline">Option B architecture guardrails</a> to keep data contracts honest.</p>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="space-y-4">
+                            <h3 class="text-2xl font-semibold text-indigo-200">Meeting 3 — Secure the Delivery Window</h3>
+                            <p class="text-base text-slate-200 leading-relaxed">Once enrichment resumed, we shifted to program risk. Production remained stable, but CR's volatility and the September 30 deadline forced a conversation about evidence collection, triage cadence, and the looming CDP Spark migration.</p>
+                            <div class="challenge-card p-6 rounded-2xl">
+                                <h4 class="text-lg font-semibold text-white mb-3">Program Risks to Track</h4>
+                                <ul class="list-disc list-inside text-sm text-slate-100 space-y-2">
+                                    <li><strong>Evidence deficit:</strong> Without steady pending data, we cannot prove readiness for DDA Going Primary.</li>
+                                    <li><strong>Coordination tax:</strong> Daily triage with utilities, digital channels, and BLR is now mandatory office hours.</li>
+                                    <li><strong>Latency expectations:</strong> Teams must plan around the inherent 2–3 minute enrichment lag (1 minute CDP batch + 2 minute enrichment retry).</li>
+                                    <li><strong>Capacity conflict:</strong> CDP Spark migration competes for the same engineers critical to enrichment QA.</li>
+                                </ul>
+                            </div>
+                            <p class="text-sm text-slate-200 leading-relaxed">These risks mirror lessons from our <a href="dda-going-primary-dashboard-strategy.html" class="anchor-link underline">dashboard strategy</a>: make bottlenecks visible, assign owners, and time-box decisions.</p>
+                        </article>
+                    </section>
+
+                    <section id="implementation-guide" class="space-y-6">
+                        <h2 class="text-3xl font-bold text-white">Implementation Guide</h2>
+                        <p class="text-base text-slate-200 leading-relaxed">Deploy this in your own sandbox or UAT environment to harden enrichment before the next release.</p>
+                        <ol class="list-decimal list-inside space-y-4 text-base text-slate-100 leading-relaxed">
+                            <li><strong>Instrument the core fields:</strong> Extend dashboards with <code>enrichedMerchantDetail_v3</code> status, merchant geography completeness, and batch job run history.</li>
+                            <li><strong>Codify conditioned data requests:</strong> Publish a test-data checklist (state, city, postal code, MCC) and require CDP sign-off before QA cycles begin.</li>
+                            <li><strong>Automate payload linting:</strong> Add schema validation to ingestion pipelines, similar to the automated checks outlined in <a href="end-to-end-and-api-testing-for-etd.html" class="anchor-link underline">our ETD testing blueprint</a>.</li>
+                            <li><strong>Schedule daily triage:</strong> Treat the utilities sync as open office hours; log every action item with timestamps and owners in Confluence.</li>
+                            <li><strong>Protect historical data:</strong> After rerunning batch jobs, run reconciliation queries to confirm no records were nulled; escalate anomalies to BLR immediately.</li>
+                        </ol>
+                        <div class="framework-box p-6 rounded-2xl">
+                            <h3 class="text-xl font-semibold text-white mb-3">Quick-Start Checklist</h3>
+                            <ul class="list-disc list-inside text-sm text-slate-100 space-y-2">
+                                <li>🔍 Trace IDs mapped from API logs to Splunk in under 2 minutes.</li>
+                                <li>🧾 Daily ledger of pending vs. posted coverage with evidence screenshots.</li>
+                                <li>🤝 Named owners for CDP conditioning, ETU enrichment, Digital Channels validation.</li>
+                                <li>📦 Backup of pre-rerun transaction tables to guard against data drops.</li>
+                                <li>📊 Latency dashboard refreshed every 15 minutes for triage visibility.</li>
+                            </ul>
+                        </div>
+                    </section>
+
+                    <section id="reflection-questions" class="space-y-6">
+                        <h2 class="text-3xl font-bold text-white">Reflection Questions</h2>
+                        <div class="reflection-box p-6 rounded-2xl">
+                            <ul class="list-disc list-inside text-base text-slate-100 space-y-3 leading-relaxed">
+                                <li>Where does your current observability stack surface null enrichment payloads before customers do?</li>
+                                <li>How are pending transaction lifecycles protected from data staleness during long triage windows?</li>
+                                <li>What governance mechanism forces upstream teams to ship conditioned data as part of definition of ready?</li>
+                                <li>How will the CDP Spark migration (or equivalent platform initiatives) cannibalize enrichment QA capacity, and what is your contingency?</li>
+                            </ul>
+                        </div>
+                    </section>
+
+                    <section id="atomic-notes" class="space-y-6">
+                        <h2 class="text-3xl font-bold text-white">Atomic Notes</h2>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-5 text-sm text-slate-100 leading-relaxed">
+                            <div class="highlight-box p-4 rounded-2xl space-y-2">
+                                <h3 class="text-base font-semibold text-white">Observability</h3>
+                                <ul class="list-disc list-inside space-y-1">
+                                    <li>HTTP 204/206 flagged the silent failure.</li>
+                                    <li>Trace IDs kept Prod vs. CR comparisons honest.</li>
+                                    <li>Add merchant geography completeness to dashboards.</li>
+                                </ul>
+                            </div>
+                            <div class="highlight-box p-4 rounded-2xl space-y-2">
+                                <h3 class="text-base font-semibold text-white">Data Integrity</h3>
+                                <ul class="list-disc list-inside space-y-1">
+                                    <li>CDP payloads must include city, state, zip.</li>
+                                    <li>Backups required before rerunning batch jobs.</li>
+                                    <li>Label DDA primary defects distinctly for recall.</li>
+                                </ul>
+                            </div>
+                            <div class="highlight-box p-4 rounded-2xl space-y-2">
+                                <h3 class="text-base font-semibold text-white">Coordination</h3>
+                                <ul class="list-disc list-inside space-y-1">
+                                    <li>Daily triage sync acts as office hours.</li>
+                                    <li>Invite Digital Channels as optional to avoid overload.</li>
+                                    <li>Real-time fixes require cross-team presence.</li>
+                                </ul>
+                            </div>
+                            <div class="highlight-box p-4 rounded-2xl space-y-2">
+                                <h3 class="text-base font-semibold text-white">Strategic Pressure</h3>
+                                <ul class="list-disc list-inside space-y-1">
+                                    <li>September 30 readiness date is at risk without evidence.</li>
+                                    <li>Option C is deprecated; Option B remains the north star.</li>
+                                    <li>Data center migration competes for CDP bandwidth.</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section id="related-reading" class="space-y-6">
+                        <h2 class="text-3xl font-bold text-white">Related Reading &amp; Next Steps</h2>
+                        <p class="text-base text-slate-200 leading-relaxed">Keep the momentum by pairing this playbook with complementary system design and QA narratives.</p>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-5 text-sm">
+                            <a href="strategic-transaction-history-architecture.html" class="example-box p-5 rounded-2xl block hover:shadow-lg transition">
+                                <h3 class="text-lg font-semibold text-white mb-2">Strategic Transaction History Architecture</h3>
+                                <p class="text-slate-100 leading-relaxed">Understand how Option B keeps data contracts resilient when MQ limits appear.</p>
+                            </a>
+                            <a href="end-to-end-and-api-testing-for-etd.html" class="example-box p-5 rounded-2xl block hover:shadow-lg transition">
+                                <h3 class="text-lg font-semibold text-white mb-2">End-to-End &amp; API Testing for ETD</h3>
+                                <p class="text-slate-100 leading-relaxed">Adopt layered QA patterns to prevent enrichment regressions before they hit CR.</p>
+                            </a>
+                        </div>
+                        <p class="text-sm text-slate-400 leading-relaxed">Want the daily operations layer? Subscribe to the <a href="../newsletter.html" class="anchor-link underline">Cruz AI Operations Dispatch</a> for ongoing enrichment metrics.</p>
+                    </section>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="border-t border-slate-800 py-8 px-6">
+        <div class="container mx-auto text-center text-slate-500 text-sm">
+            <p class="font-semibold tracking-tight">ChrisCruz<span class="text-indigo-400">.ai</span></p>
+            <p>&copy; 2025. Incident management and fintech reliability insights. All rights reserved.</p>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -361,6 +361,17 @@
             <div class="writing-grid">
                 <article class="writing-card">
                     <div class="writing-meta">
+                        <span class="writing-category">Incident Response</span>
+                        <span class="writing-date">September 19, 2025</span>
+                    </div>
+                    <h3 class="writing-title">Restoring Transaction Enrichment in CR</h3>
+                    <p class="writing-excerpt">
+                        How cross-team triage diagnosed ETU nulls, revived batch processing, and reset data conditioning rituals to recover enriched merchant details in the CR environment.
+                    </p>
+                    <a href="blogs/troubleshooting-transaction-enrichment-api.html" class="writing-link">Read the Incident Playbook →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
                         <span class="writing-category">Fintech Architecture</span>
                         <span class="writing-date">September 18, 2025</span>
                     </div>


### PR DESCRIPTION
## Summary
- add a new incident response blog post covering the CR transaction enrichment triage effort with executive summary, implementation guide, and reflection prompts
- update the blog listing and homepage writing grid to feature the new article entry with metadata and link

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc8094210c8325bf186ca66b300b4e