### PR TITLE
Add Q4 planning playbook blog and homepage link

### DIFF
--- a/blogs/q4-quarterly-planning-transaction-history.html
+++ b/blogs/q4-quarterly-planning-transaction-history.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Q4 Planning Playbook for Transaction History & CDP Migration | ChrisCruz.ai</title>
+    <meta name="description" content="Executive briefing on Q4 priorities for the Transaction History API and BLR2 data platforms. Includes strategic focus, execution framework, implementation guide, risks, and atomic notes for leaders."/>
+    <meta name="keywords" content="Q4 planning, Transaction History API, CDP migration, data reconciliation, THV4, AWS migration, performance optimization"/>
+    <meta name="author" content="Christopher Manuel Cruz-Guzman"/>
+    <meta property="og:title" content="Q4 Planning Playbook for Transaction History & CDP Migration"/>
+    <meta property="og:description" content="Executive summary, key insights, and implementation guardrails for Wil2 and BLR2 teams heading into Q4."/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:url" content="https://chriscruz.ai/blogs/q4-quarterly-planning-transaction-history.html"/>
+    <meta property="og:image" content="https://chriscruz.ai/images/q4-planning.jpg"/>
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:title" content="Q4 Planning Playbook for Transaction History & CDP Migration"/>
+    <meta name="twitter:description" content="Strategic focus, delivery framework, and implementation guardrails for Wil2 and BLR2 teams heading into Q4."/>
+    <meta name="article:published_time" content="2025-09-20T00:00:00Z"/>
+    <meta name="article:author" content="Christopher Manuel Cruz-Guzman"/>
+    <meta name="article:section" content="Quarterly Planning"/>
+    <meta name="article:tag" content="Q4 planning, Transaction History, AWS migration, data reconciliation"/>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #0b0b0f;
+            color: #e7e7ec;
+        }
+        .medium-prose {
+            max-width: 820px;
+            margin: 0 auto;
+            line-height: 1.7;
+        }
+        .blog-surface {
+            background: rgba(17, 17, 25, 0.85);
+            border: 1px solid rgba(148, 163, 184, 0.12);
+            box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+        }
+        .gradient-text {
+            background: linear-gradient(120deg, #38bdf8, #6366f1, #f97316);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .toc-link {
+            color: #94a3b8;
+        }
+        .toc-link:hover {
+            color: #f97316;
+        }
+        .highlight-box {
+            background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(56, 189, 248, 0.14));
+            border: 1px solid rgba(99, 102, 241, 0.35);
+            box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+        }
+        .challenge-card {
+            background: linear-gradient(135deg, rgba(239, 68, 68, 0.16), rgba(244, 114, 182, 0.12));
+            border: 1px solid rgba(248, 113, 113, 0.4);
+        }
+        .framework-box {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.14), rgba(45, 212, 191, 0.1));
+            border: 1px solid rgba(16, 185, 129, 0.35);
+        }
+        .example-box {
+            background: linear-gradient(135deg, rgba(59, 130, 246, 0.16), rgba(147, 51, 234, 0.12));
+            border: 1px solid rgba(59, 130, 246, 0.35);
+        }
+        .reflection-box {
+            background: linear-gradient(135deg, rgba(251, 191, 36, 0.16), rgba(234, 179, 8, 0.12));
+            border: 1px solid rgba(250, 204, 21, 0.35);
+        }
+        .section-divider {
+            height: 1px;
+            background: linear-gradient(90deg, rgba(148, 163, 184, 0), rgba(148, 163, 184, 0.45), rgba(148, 163, 184, 0));
+        }
+        .quote {
+            border-left: 4px solid #38bdf8;
+            padding-left: 1.25rem;
+            color: #cbd5f5;
+        }
+        .tag-pill {
+            background: rgba(148, 163, 184, 0.16);
+            border: 1px solid rgba(148, 163, 184, 0.35);
+            border-radius: 9999px;
+            padding: 0.35rem 0.9rem;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        a.inline-link {
+            color: #38bdf8;
+        }
+        a.inline-link:hover {
+            color: #f97316;
+        }
+    </style>
+</head>
+<body class="antialiased">
+    <header class="fixed top-0 left-0 right-0 z-40 bg-black/40 backdrop-blur-md border-b border-slate-800/60">
+        <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+            <a href="../brand-hub.html" class="text-xl font-bold tracking-tight">ChrisCruz<span class="text-sky-400">.ai</span></a>
+            <nav class="hidden md:flex space-x-8 text-sm text-slate-300">
+                <a href="../brand-hub.html" class="hover:text-sky-400 transition">Empire</a>
+                <a href="../projects" class="hover:text-sky-400 transition">Projects</a>
+                <a href="../manifesto.html" class="hover:text-sky-400 transition">Manifesto</a>
+                <a href="../blogs/index.html" class="hover:text-sky-400 transition">All Writing</a>
+            </nav>
+            <span class="tag-pill">Quarterly Planning</span>
+        </div>
+    </header>
+
+    <main class="pt-24 pb-24">
+        <section class="px-6 py-16">
+            <div class="medium-prose text-center">
+                <p class="text-slate-400 text-sm uppercase tracking-[0.35em] mb-4">Q4 Planning Memo</p>
+                <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight mb-6">Q4 Planning Playbook for <span class="gradient-text">Transaction History &amp; CDP Migration</span></h1>
+                <p class="text-lg text-slate-300 mb-8">A unified narrative for Wil2 and BLR2 leaders to execute on data reconciliation, THV4 delivery, and CDP decommissioning while protecting performance, observability, and consumer trust.</p>
+                <div class="flex flex-wrap justify-center gap-4 text-sm text-slate-400">
+                    <span>September 20, 2025</span>
+                    <span class="text-slate-600">•</span>
+                    <span>8 minute read</span>
+                    <span class="text-slate-600">•</span>
+                    <span>By Christopher Manuel Cruz-Guzman</span>
+                </div>
+            </div>
+        </section>
+
+        <section class="px-6 pb-16">
+            <div class="medium-prose blog-surface rounded-3xl p-10 space-y-12">
+                <div class="flex flex-wrap gap-3 text-xs uppercase tracking-[0.2em] text-slate-400">
+                    <a href="#executive-summary" class="toc-link">Executive Summary</a>
+                    <a href="#key-insights" class="toc-link">Key Insights</a>
+                    <a href="#detailed-breakdown" class="toc-link">Detailed Breakdown</a>
+                    <a href="#implementation-guide" class="toc-link">Implementation Guide</a>
+                    <a href="#reflection-questions" class="toc-link">Reflection Questions</a>
+                    <a href="#atomic-notes" class="toc-link">Atomic Notes</a>
+                </div>
+
+                <div class="highlight-box rounded-2xl p-8" id="executive-summary">
+                    <h2 class="text-2xl font-bold text-slate-100 mb-4">Executive Summary</h2>
+                    <p class="text-slate-200 mb-4">Wil2 and BLR2 enter Q4 with a dual mandate: mature Transaction History Version 4 into a production-grade experience while exiting the CDP data center through AWS-native pipelines. The north star is simple—achieve <span class="font-semibold text-sky-300">99%+ reconciliation</span>, land THV4 with consumer-ready resilience, and harden observability before scaling traffic.</p>
+                    <ul class="list-disc pl-6 space-y-2 text-slate-200">
+                        <li>Data quality is the lead domino: reconciliation sits at <span class="font-semibold">92%</span>, driving a quarter-long push with SOR, ODS, and FCDP partners to close gaps.</li>
+                        <li>THV4 represents a <span class="font-semibold">100-point</span> engineering investment spanning bug fixes, QA, pagination tuning, Cassandra resiliency, FMEA, and runbook creation.</li>
+                        <li>BLR2 shoulders a <span class="font-semibold">300-point</span> quarter anchored in CDP decommissioning, AWS migration, and merchant tagging backfills—all under a critical timeline.</li>
+                        <li>Cross-team friction points—API gateway decisions, alert fatigue, photon upgrades, and consumer onboarding—demand explicit owners and fast decisions.</li>
+                    </ul>
+                </div>
+
+                <div class="space-y-6" id="key-insights">
+                    <h2 class="text-3xl font-bold text-slate-100">Key Insights</h2>
+                    <div class="grid gap-6 md:grid-cols-2">
+                        <div class="challenge-card rounded-2xl p-6">
+                            <h3 class="text-xl font-semibold text-rose-200 mb-3">Critical Decisions</h3>
+                            <p class="text-rose-100 mb-3">“We need to make a quick decision… we’ve been sitting on this for a very long time.” — Kiran on the API gateway direction. Envoy remains aspirational; Q4 requires a call to unblock GLB creation and production readiness.</p>
+                            <ul class="list-disc pl-5 text-rose-100 space-y-1 text-sm">
+                                <li>Decide between Envoy and existing gateway before sprint 2.</li>
+                                <li>Align alerting scope so production signals stay actionable.</li>
+                                <li>Stand up photon upgrade tracker for every API touchpoint.</li>
+                            </ul>
+                        </div>
+                        <div class="framework-box rounded-2xl p-6">
+                            <h3 class="text-xl font-semibold text-emerald-100 mb-3">Performance Expectations</h3>
+                            <p class="text-emerald-50 mb-3">THV4 must meet or beat V3 latency at heavy load. Targets call for <span class="font-semibold">3K–5K TPS</span> sustained throughput while tuning memory and CPU. BlazeMeter limits may cap perf env tests at ~3K TPS; the team will stress 2x expected load.</p>
+                            <ul class="list-disc pl-5 text-emerald-50 space-y-1 text-sm">
+                                <li>Document perf ceilings alongside mitigations.</li>
+                                <li>Pair FMEA scenarios with telemetry validation.</li>
+                                <li>Capture runbooks for incident hand-off prior to go-live.</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="example-box rounded-2xl p-6">
+                        <h3 class="text-xl font-semibold text-indigo-100 mb-3">Consumer Momentum</h3>
+                        <p class="text-indigo-50 mb-4">Wil2 is juggling V2 ➜ V3 migrations, digital channel onboarding, and aggregator education. An AI-powered onboarding agent is planned to parse documentation, videos, and FAQs—reducing support toil and accelerating adoption.</p>
+                        <div class="flex flex-wrap gap-3 text-xs text-indigo-100">
+                            <span class="tag-pill bg-indigo-500/10 border-indigo-400/40">AI Onboarding Agent</span>
+                            <span class="tag-pill bg-indigo-500/10 border-indigo-400/40">Swagger &amp; API Store Alignment</span>
+                            <span class="tag-pill bg-indigo-500/10 border-indigo-400/40">Cross-Product Consistency</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="section-divider"></div>
+
+                <div class="space-y-8" id="detailed-breakdown">
+                    <h2 class="text-3xl font-bold text-slate-100">Detailed Breakdown</h2>
+                    <div class="space-y-6">
+                        <h3 class="text-2xl font-semibold text-slate-200">Wil2 &mdash; Transaction History API</h3>
+                        <div class="space-y-4 text-slate-300">
+                            <p class="quote">“It’s not about showing the numbers… identify each of the issues, fix the differences, work with the CDP team.” — Kiran on reconciliation discipline.</p>
+                            <ul class="list-disc pl-6 space-y-2">
+                                <li><span class="font-semibold text-slate-100">Data Reconciliation (Priority #1):</span> Current metrics hover at <span class="font-semibold">92%</span>. The end-of-quarter target is <span class="font-semibold">99%+</span>, requiring sustained analysis of SOR vs. ODS discrepancies, validation of SOR fixes, and tighter loops with ingestion teams.</li>
+                                <li><span class="font-semibold text-slate-100">THV4 Development &amp; Stabilization:</span> Estimated at <span class="font-semibold">~100 story points</span>, covering pagination QA, defect burn-down, Cassandra retry resiliency, GLB creation, true CI/CD, breached-account routing strategies, and cross-product consistency validation.</li>
+                                <li><span class="font-semibold text-slate-100">Performance &amp; FMEA Tracks:</span> Performance testing breaks out as its own epic to tune latency and resource usage, while FMEA scenarios stress profile table dependencies and downstream integrations to confirm graceful degradation.</li>
+                                <li><span class="font-semibold text-slate-100">Consumer Integration Testing:</span> Digital channels and aggregators are queued for ETD V3 testing; support stories remain open to triage defects and educate teams transitioning from V2.</li>
+                                <li><span class="font-semibold text-slate-100">Production Readiness:</span> Observability, monitoring, alert tuning, Deadpool integration, runbooks, and swagger/API store parity are bundled together to reduce post-launch friction.</li>
+                                <li><span class="font-semibold text-slate-100">Operational Friction:</span> Alert fatigue continues—“We’re getting hundreds of alerts… becoming numb to them,” Chris flagged. Photon upgrades need a centralized tracker, and the Envoy vs. existing gateway decision blocks routing design.</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div class="space-y-6">
+                        <h3 class="text-2xl font-semibold text-slate-200">BLR2 &mdash; CDP Exit &amp; AWS Migration</h3>
+                        <div class="space-y-4 text-slate-300">
+                            <p class="quote">“CDP DC exit is a driving factor. AWS migration is a solution we came up with to do the CDP DC exit.” — Kiran</p>
+                            <ul class="list-disc pl-6 space-y-2">
+                                <li><span class="font-semibold text-slate-100">Migration Imperative:</span> Decommission CDP and land workloads on AWS by year-end. Success promises faster processing and aligns with enterprise data strategy.</li>
+                                <li><span class="font-semibold text-slate-100">Data Quality Lift:</span> Recon sits at <span class="font-semibold">92%</span>; leadership insists it is “unacceptable” to show externally. The goal mirrors Wil2 at 99%, with iterative back-and-forth validation alongside FCDP counterparts.</li>
+                                <li><span class="font-semibold text-slate-100">Major Workstreams:</span> Merchant tagging historical loads, dynamic orchestration, consumer integration testing, account breach validation, CDP exit migrations, and SOD ingestion redesign (100 pts) all compete for focus.</li>
+                                <li><span class="font-semibold text-slate-100">Capacity &amp; Resourcing:</span> Q4 plan totals <span class="font-semibold">~300 story points</span>. A new AWS-experienced engineer joins October 1 to absorb migration load.</li>
+                                <li><span class="font-semibold text-slate-100">Risk Landscape:</span> Tight timelines, monitoring readiness, data inconsistencies, and cross-team coordination top the list. Incremental migration and proactive comms anchor the mitigation plan.</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="section-divider"></div>
+
+                <div class="space-y-6" id="implementation-guide">
+                    <h2 class="text-3xl font-bold text-slate-100">Implementation Guide</h2>
+                    <div class="framework-box rounded-2xl p-6 space-y-4">
+                        <h3 class="text-xl font-semibold text-emerald-100">4-Phase Q4 Execution Framework</h3>
+                        <ol class="list-decimal pl-6 space-y-3 text-emerald-50">
+                            <li><span class="font-semibold">Stabilize the Core (Weeks 1-3):</span> Lock the API gateway decision, formalize photon tracker, stand up reconciliation war room, and confirm perf environment limits.</li>
+                            <li><span class="font-semibold">Build &amp; Test (Weeks 2-6):</span> Burn down THV4 backlog, execute BlazeMeter runs to 2x TPS, and complete FMEA scripts targeting profile table, downstream service, and queue failures.</li>
+                            <li><span class="font-semibold">Harden &amp; Document (Weeks 5-8):</span> Finalize runbooks, calibrate alert thresholds, publish onboarding videos, and deploy the AI documentation agent prototype.</li>
+                            <li><span class="font-semibold">Migrate &amp; Monitor (Weeks 7-12):</span> Sequence AWS cutovers, verify merchant tagging loads, track recon dashboards, and run cross-team go/no-go reviews.</li>
+                        </ol>
+                    </div>
+                    <div class="grid gap-6 md:grid-cols-2">
+                        <div class="example-box rounded-2xl p-6 space-y-3">
+                            <h3 class="text-lg font-semibold text-indigo-100">Example Play &mdash; Recon Issue Response</h3>
+                            <p class="text-indigo-50">1) Identify variance in dashboard, 2) assign SOR/ODS pairing owner, 3) validate upstream fix with FCDP, 4) rerun reconciliation batch, 5) archive resolution in tracker, 6) push update to AI onboarding corpus for consumer transparency.</p>
+                            <p class="text-indigo-200 text-sm">This loop maintains the “identify &amp; fix” discipline Kiran demanded.</p>
+                        </div>
+                        <div class="highlight-box rounded-2xl p-6 space-y-3">
+                            <h3 class="text-lg font-semibold text-slate-100">Cross-Links for Deeper Context</h3>
+                            <ul class="space-y-2 text-slate-200 text-sm">
+                                <li>Revisit the <a class="inline-link" href="../blogs/strategic-transaction-history-architecture.html">Strategic Transaction History Architecture</a> memo to align on platform north stars.</li>
+                                <li>Study the <a class="inline-link" href="../blogs/end-to-end-and-api-testing-for-etd.html">ETD Testing Strategy</a> for reusable QA patterns.</li>
+                                <li>Share the <a class="inline-link" href="../blogs/dda-api-migration-v2-to-v3.html">DDA Migration Guide</a> with lagging V2 consumers.</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="section-divider"></div>
+
+                <div class="reflection-box rounded-2xl p-8 space-y-6" id="reflection-questions">
+                    <h2 class="text-3xl font-bold text-slate-900">Reflection Questions</h2>
+                    <ol class="list-decimal pl-6 space-y-3 text-slate-900">
+                        <li>What’s blocking a final API gateway decision, and who owns clearing it this sprint?</li>
+                        <li>How quickly can we convert the 92% reconciliation metric into a daily 99% trend, and what joint rituals with SOR/CDP partners are missing?</li>
+                        <li>Where does alert volume still mask true incidents, and what telemetry do we turn off, tune, or automate through the AI onboarding agent?</li>
+                        <li>How will we confirm cross-product consistency (TH vs. Cross Product APIs) before production traffic doubles?</li>
+                        <li>Which AWS migration milestones need executive escalation now to protect the year-end CDP exit?</li>
+                    </ol>
+                </div>
+
+                <div class="space-y-6" id="atomic-notes">
+                    <h2 class="text-3xl font-bold text-slate-100">Atomic Notes</h2>
+                    <ul class="grid gap-4 md:grid-cols-2 text-slate-300">
+                        <li class="highlight-box rounded-2xl p-4">CDP exit portfolio includes <span class="font-semibold">Spark job migrations (175 pts)</span>, SOD ingestion redesign (100 pts), Cascade 2.5 uplift (50 pts), MMS updates (25 pts), DDA primary (205 pts), dynamic orchestration (30 pts), merchant tagging historical load (10 pts), ETD V3 consumer testing (10 pts), and Account Breach validation (30 pts).</li>
+                        <li class="highlight-box rounded-2xl p-4">Photon upgrades progressing toward <span class="font-semibold">v3.4.5</span>; need confluence tracker to log version per API and ensure deployments accompany feature work.</li>
+                        <li class="highlight-box rounded-2xl p-4">Wil2 backlog sizing signals <span class="font-semibold">THV4 development (50 pts)</span>, <span class="font-semibold">performance testing (25 pts)</span>, <span class="font-semibold">FMEA (25 pts)</span>, <span class="font-semibold">production readiness (25 pts)</span>, and <span class="font-semibold">consumer integration (20 pts)</span>.</li>
+                        <li class="highlight-box rounded-2xl p-4">Alert fatigue surfaced via Splunk emails and build notifications; product stakeholders should be unsubscribed from BAU noise while engineering tunes signal-to-noise ratios.</li>
+                        <li class="highlight-box rounded-2xl p-4">Account breach flow may route to SOR for initial go-live (<span class="font-semibold">&lt;0.1 TPS</span>) to avoid complexity during THV4 launch.</li>
+                        <li class="highlight-box rounded-2xl p-4">New AWS hire onboarded Oct 1 with prior migration experience—deploy toward high-burn CDP exit user stories early.</li>
+                    </ul>
+                </div>
+
+                <div class="section-divider"></div>
+
+                <footer class="space-y-4 text-sm text-slate-400">
+                    <p>Want more context on the platform journey? Explore the <a class="inline-link" href="../blogs/troubleshooting-transaction-enrichment-api.html">incident retrospectives</a> or the <a class="inline-link" href="../blogs/system-thinking-empire-building.html">systems thinking essays</a> that shaped this playbook.</p>
+                    <p>&copy; 2025 Christopher Manuel Cruz-Guzman. All rights reserved.</p>
+                </footer>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -361,6 +361,18 @@
             <div class="writing-grid">
                 <article class="writing-card">
                     <div class="writing-meta">
+                        <span class="writing-category">Quarterly Planning</span>
+                        <span class="writing-date">September 20, 2025</span>
+                    </div>
+                    <h3 class="writing-title">Q4 Playbook: THV4 &amp; CDP Exit Alignment</h3>
+                    <p class="writing-excerpt">
+                        Executive summary, key insights, and implementation guardrails for Wil2 and BLR2 teams to land THV4,
+                        drive reconciliation to 99%+, and complete the CDP data center exit.
+                    </p>
+                    <a href="blogs/q4-quarterly-planning-transaction-history.html" class="writing-link">Read the Q4 Brief →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
                         <span class="writing-category">Incident Response</span>
                         <span class="writing-date">September 19, 2025</span>
                     </div>


### PR DESCRIPTION
## Summary
- add a Q4 planning playbook blog covering Wil2 and BLR2 priorities with executive summary, insights, implementation guide, and atomic notes
- link the new planning brief from the homepage writing grid for quick access

## Testing
- no automated tests were run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cc8360107c8325ba8c62be1d59fba8