### PR TITLE
Refresh transaction history architecture blog content

### DIFF
--- a/blogs/strategic-transaction-history-architecture.html
+++ b/blogs/strategic-transaction-history-architecture.html
@@ -4,17 +4,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Strategic Architectural Decision for Transaction History Services | ChrisCruz.ai</title>
-    <meta name="description" content="Executive blueprint for adopting Option B for cross-product transaction history, covering context, decision logic, implementation guide, and next steps toward a unified CDA experience by Q1 2026.">
-    <meta name="keywords" content="Transaction history, architecture decision, Option B, cross-product API, CDA, AWS ingestion, MQ constraint, fintech strategy">
+    <meta name="description" content="Details Option A, B, and C with migration strategy, decision tree for adoption, and timeline-driven choices tied to end-to-end testing.">
+    <meta name="keywords" content="Transaction history, architecture decision, Option B, cross-product API, CDA, AWS ingestion, MQ constraint, fintech strategy, end-to-end testing, tech debt, Cross-Product API, Transaction History API, consumer migration">
     <meta name="author" content="Christopher Manuel Cruz-Guzman">
     <meta property="og:title" content="Strategic Architectural Decision for Transaction History Services">
-    <meta property="og:description" content="Why Option B is the pragmatic path for transaction history resilience and how the team is executing toward Q1 2026 CDA delivery.">
+    <meta property="og:description" content="Compare Option A, B, and C with consumer migration strategy, adoption decision tree, and the end-to-end testing deadline driving tech debt tradeoffs.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://chriscruz.ai/blogs/strategic-transaction-history-architecture.html">
     <meta property="og:image" content="https://chriscruz.ai/images/api-strategy-decision.jpg">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Strategic Architectural Decision for Transaction History Services">
-    <meta name="twitter:description" content="Option B wins: the architectural playbook for resilient transaction history and CDA readiness.">
+    <meta name="twitter:description" content="Option A vs. B vs. C tradeoffs, consumer migration decision tree, and timeline-driven calls tied to end-to-end testing.">
     <meta name="article:published_time" content="2025-09-18T00:00:00Z">
     <meta name="article:author" content="Christopher Manuel Cruz-Guzman">
     <meta name="article:section" content="Fintech Architecture">
@@ -66,6 +66,76 @@
             background: rgba(45, 212, 191, 0.12);
             border: 1px solid rgba(34, 197, 94, 0.35);
             border-radius: 18px;
+        }
+        .target-state-banner {
+            background: rgba(14, 165, 233, 0.18);
+            border: 1px solid rgba(14, 165, 233, 0.45);
+            border-radius: 18px;
+            padding: 24px;
+        }
+        .callout-box {
+            background: linear-gradient(135deg, rgba(250, 204, 21, 0.14), rgba(248, 113, 113, 0.16));
+            border: 1px solid rgba(234, 179, 8, 0.35);
+            border-radius: 18px;
+            padding: 24px;
+        }
+        .callout-emphasis {
+            font-weight: 600;
+            color: #fef9c3;
+        }
+        .decision-tree {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1.5rem;
+        }
+        .decision-branch {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.75rem;
+        }
+        .decision-node {
+            padding: 0.9rem 1.6rem;
+            border-radius: 9999px;
+            background: rgba(56, 189, 248, 0.18);
+            border: 1px solid rgba(56, 189, 248, 0.45);
+            font-weight: 600;
+            color: #e0f2fe;
+        }
+        .decision-leaf {
+            padding: 0.75rem 1.4rem;
+            border-radius: 9999px;
+            background: rgba(129, 140, 248, 0.18);
+            border: 1px solid rgba(129, 140, 248, 0.45);
+            font-weight: 500;
+            color: #ede9fe;
+        }
+        .decision-connector {
+            width: 2px;
+            height: 2.5rem;
+            background: rgba(148, 163, 184, 0.5);
+        }
+        table.option-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.95rem;
+        }
+        table.option-table th,
+        table.option-table td {
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            padding: 12px 16px;
+            vertical-align: top;
+        }
+        table.option-table th {
+            background: rgba(15, 23, 42, 0.6);
+            color: #e2e8f0;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        table.option-table tbody tr:nth-child(even) {
+            background: rgba(15, 23, 42, 0.35);
         }
         .atomic-list li {
             border-bottom: 1px solid rgba(148, 163, 184, 0.25);
@@ -180,6 +250,13 @@
                     </p>
                 </div>
 
+                <div class="target-state-banner">
+                    <p class="text-xs uppercase tracking-[0.3em] text-sky-200 mb-2">Target State (Cross-Product API)</p>
+                    <p class="text-slate-100 text-lg leading-relaxed">
+                        This initiative should be understood not just as an architectural decision but as a step toward our Cross-Product API target state. Every interim tradeoff — including the technical debt we are prepared to carry — is in service of migrating consumers off legacy connections and converging on a single, resilient utility fabric.
+                    </p>
+                </div>
+
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="highlight-box p-6">
                         <h3 class="text-xl font-semibold mb-3">Key Insights</h3>
@@ -188,6 +265,7 @@
                             <li>Option B keeps Q1 2026 CDA viability alive while nudging consumers toward the future cross-product API.</li>
                             <li>AWS ingestion acceleration — compressing batch windows from ~2 hours to 10–15 minutes — is the mitigation lever for data consistency risk.</li>
                             <li>Consumer teams must shoulder dual-service orchestration as planned technical debt, balanced by a clear decommissioning roadmap.</li>
+                            <li>Sam is now the DDA point of contact, streamlining coordination with consumers as they migrate.</li>
                         </ul>
                     </div>
                     <div class="challenge-card p-6">
@@ -212,17 +290,136 @@
                             Related playbook: <a href="../blogs/dda-going-primary-dashboard-strategy.html" class="cross-link">DDA Going Primary Dashboard Strategy</a> for monitoring the readiness runway.
                         </p>
                     </div>
-                    <div class="space-y-4">
+                    <div class="space-y-6">
                         <h3 class="text-lg font-semibold text-slate-100">2. Option Review</h3>
-                        <ul class="space-y-4 text-slate-100">
-                            <li><strong>Option A:</strong> Embed SOR failover directly into Cross-Product. <em>Status:</em> Dismissed as infeasible within Q1 2026 scope due to complexity and risk of bloating the target-state API.</li>
-                            <li><strong>Option B:</strong> Consumers call DDA Transaction History v4 for list views and Cross-Product for search. <em>Status:</em> Selected. Medium complexity, leverages existing SOR integration, protects delivery timeline, and keeps consumer-side ownership explicit.</li>
-                            <li><strong>Option C:</strong> Intelligent routing inside Cross-Product. <em>Status:</em> Invalidated. Network-hop latency (30–50ms) raised concerns; the refined shared-library variant — scoped only to batch processing and resiliency failovers — collapsed because it would force ~40 new persistent MQ connections on infrastructure that is already at capacity and not slated for further investment.</li>
-                        </ul>
+                        <p class="text-slate-200 leading-relaxed">
+                            Three viable patterns emerged. Each pushes us toward the Cross-Product API target in different ways, and each demands a conscious tolerance for technical debt so we can hit the end-to-end testing milestone on schedule.
+                        </p>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div class="highlight-box p-5 space-y-3">
+                                <h4 class="text-base font-semibold text-slate-100 uppercase tracking-wide">Option A: System-of-Record Integration</h4>
+                                <p class="text-slate-200 text-sm">
+                                    The most resilient path embeds DDA system-of-record logic directly into Cross-Product. It creates a single utility surface with built-in failover.
+                                </p>
+                                <p class="text-slate-300 text-xs">
+                                    Tradeoff: Highest complexity and change scope; would delay consumer migration timelines well past the forcing milestone.
+                                </p>
+                            </div>
+                            <div class="highlight-box p-5 space-y-3 border border-emerald-400/50">
+                                <h4 class="text-base font-semibold text-emerald-200 uppercase tracking-wide">Option B: HTTP Orchestration Model</h4>
+                                <p class="text-slate-200 text-sm">
+                                    Consumers orchestrate HTTP requests across DDA Transaction History for lists and Cross-Product for search. It is achievable within the current timeline, respects existing SOR integrations, and remains the realistic fallback if other approaches stall.
+                                </p>
+                                <p class="text-slate-300 text-xs">
+                                    Tradeoff: Requires coordinated consumer migration and disciplined retirement of dual-call logic after rollout; we knowingly accept this debt to land the milestone.
+                                </p>
+                            </div>
+                            <div class="challenge-card p-5 space-y-3 border border-red-400/50">
+                                <h4 class="text-base font-semibold text-rose-200 uppercase tracking-wide">Option C: Library Routing Bridge</h4>
+                                <p class="text-slate-200 text-sm">
+                                    Embeds a shared DDA library inside Cross-Product to route list traffic without a network hop, aligning strongly with the eventual utility fabric.
+                                </p>
+                                <ul class="text-slate-300 text-xs space-y-1">
+                                    <li>➕ Acts as a consumer migration bridge toward the target state.</li>
+                                    <li>➖ Adds 30–40ms latency and requires MQ connectivity that Mainframe/SOR partners rejected.</li>
+                                    <li>➖ No new consumer connections, yet only viable if teams roll off legacy API versions while rolling onto the shared library.</li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="overflow-x-auto">
+                            <table class="option-table mt-2">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Evaluation Lens</th>
+                                        <th scope="col">Option A</th>
+                                        <th scope="col">Option B</th>
+                                        <th scope="col">Option C</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>Approach Summary</td>
+                                        <td>Cross-Product absorbs SOR failover capabilities for a fully resilient utility.</td>
+                                        <td>Digital Channels and Search maintain orchestrated HTTP calls across existing APIs.</td>
+                                        <td>Cross-Product hosts the DDA library to dynamically route list and failover traffic.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Strengths</td>
+                                        <td>Ultimate resilience; single surface for all consumers once complete.</td>
+                                        <td>Timeline-safe, leverages proven integrations, keeps consumer autonomy while we migrate.</td>
+                                        <td>Aligns with target state, minimizes long-term dual-service debt, simplifies onboarding.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Key Tradeoffs / Risks</td>
+                                        <td>Engineering lift exceeds milestone window; risk of scope creep and performance regression during build.</td>
+                                        <td>Operational tech debt from dual-call logic until consumers retire legacy flows; requires strong governance.</td>
+                                        <td>Latency penalty of 30–40ms, MQ dependency rejected by Mainframe/SOR, contingent on simultaneous consumer roll-off from old versions.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Connection Model / Consumer Migration Impact</td>
+                                        <td>Direct SOR integration; demands coordinated cutovers from every consumer before go-live.</td>
+                                        <td>HTTP request choreography; straightforward fallback if other options stall and manageable within current teams.</td>
+                                        <td>Library routing bridge; requires MQ (not approved) and mandates roll-off of legacy API versions as part of the roll-on plan.</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                         <p class="text-slate-300 text-sm">
                             Architecture history fans can cross-reference <a href="../blogs/dda-api-migration-v2-to-v3.html" class="cross-link">DDA API Migration: V2 to V3</a> to see how incremental modernization succeeds.
                         </p>
                     </div>
+                    <div class="callout-box text-slate-100">
+                        <p class="text-base leading-relaxed">
+                            <span class="callout-emphasis">The upcoming end-to-end testing milestone</span> is a forcing mechanism for these decisions. To meet this deadline, we are prepared to accept additional tech debt.
+                        </p>
+                    </div>
+
+                    <div class="highlight-box p-8 space-y-4">
+                        <h3 class="text-xl font-semibold text-slate-100">Next Steps for Consumer Migration</h3>
+                        <ul class="list-disc list-inside space-y-3 text-slate-100">
+                            <li>Begin contacting consumers now about rolling off old connections and retiring unsupported API versions.</li>
+                            <li>Assess and document what each API provides to guarantee feature parity as consumers migrate to new experiences.</li>
+                            <li>Build a decision tree for adoption so every team has a clear runway:
+                                <ul class="list-disc list-inside ml-5 space-y-2 text-slate-200">
+                                    <li>Digital Channels → Cross-Product API.</li>
+                                    <li>OSC Servicing → Transaction History API.</li>
+                                    <li>Ensure roll-off plans double as roll-on support for the new orchestration paths.</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div class="framework-box p-8 space-y-4">
+                        <h3 class="text-xl font-semibold text-slate-100">Decision Tree: Adoption Guide</h3>
+                        <p class="text-slate-200">A lightweight visualization that guides consumer teams toward the correct API while migrations progress.</p>
+                        <div class="decision-tree">
+                            <div class="decision-node">Transaction History Consumers</div>
+                            <div class="decision-connector"></div>
+                            <div class="flex flex-col md:flex-row gap-6 items-center justify-center w-full">
+                                <div class="decision-branch">
+                                    <div class="decision-node">Digital Channels</div>
+                                    <div class="decision-connector"></div>
+                                    <div class="decision-leaf">Adopt Cross-Product API</div>
+                                </div>
+                                <div class="decision-branch">
+                                    <div class="decision-node">OSC Servicing</div>
+                                    <div class="decision-connector"></div>
+                                    <div class="decision-leaf">Adopt Transaction History API</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="space-y-4">
+                        <h3 class="text-lg font-semibold text-slate-100">Update: Option C Latency, Connections &amp; Feasibility</h3>
+                        <ul class="list-disc list-inside space-y-3 text-slate-100">
+                            <li>Performance testing confirmed an added 30–40ms latency penalty compared to the HTTP choreography in Option B.</li>
+                            <li>Mainframe/SOR partners formally rejected the MQ connectivity required to embed the DDA library inside Cross-Product.</li>
+                            <li>The team aligned on a fallback: if Option C cannot satisfy infrastructure constraints, remain on Option B without hesitation.</li>
+                            <li>Any future revisit of Option C must pair a roll-off from legacy API versions with a synchronized roll-on to the shared library.</li>
+                        </ul>
+                    </div>
+
                     <div class="space-y-4">
                         <h3 class="text-lg font-semibold text-slate-100">3. Post-Meeting Discovery</h3>
                         <p class="text-slate-200 leading-relaxed">
@@ -283,6 +480,30 @@
                         <li><strong>Contingency Plan:</strong> If Digital Channels or Search cannot deliver dual-service orchestration in time, reopen Option A despite the heavy lift; institute monthly readiness checkpoints.</li>
                         <li><strong>Performance Degradation Playbook:</strong> Keep cache tuning, query optimization, and capacity headroom reviews ready should Option B introduce latency spikes.</li>
                     </ul>
+                </div>
+
+                <div class="highlight-box p-8 space-y-6">
+                    <h2 class="text-2xl font-bold">Post-Meeting Follow-Up</h2>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div class="space-y-3">
+                            <h3 class="text-xl font-semibold text-slate-100">Meeting Takeaways</h3>
+                            <ul class="list-disc list-inside space-y-2 text-slate-100">
+                                <li>MQ constraints formally block Option C; Option B remains the dependable baseline.</li>
+                                <li>Sam is confirmed as the DDA point of contact to coordinate consumer migration details.</li>
+                                <li>The decision tree will steer teams toward Cross-Product or Transaction History APIs based on channel fit.</li>
+                                <li>Accepting short-term tech debt is preferable to missing the end-to-end testing milestone.</li>
+                            </ul>
+                        </div>
+                        <div class="space-y-3">
+                            <h3 class="text-xl font-semibold text-slate-100">Next Actions</h3>
+                            <ul class="list-disc list-inside space-y-2 text-slate-100">
+                                <li>Launch consumer outreach to schedule roll-off of legacy API versions.</li>
+                                <li>Document feature parity checkpoints between existing APIs and new flows.</li>
+                                <li>Publish the decision tree with adoption guidance in partner channels.</li>
+                                <li>Track readiness weekly against the end-to-end testing forcing mechanism and flag emerging tech debt.</li>
+                            </ul>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="framework-box p-8 space-y-4">


### PR DESCRIPTION
## Summary
- Update SEO metadata and add new styling helpers to support mission and call-out elements on the Strategic Transaction History Architecture blog.
- Rewrite the options section with detailed cards, a comparison table, and a timeline call-out that reinforces the end-to-end testing forcing mechanism.
- Add consumer migration guidance, a decision tree visualization, Option C feasibility update, and post-meeting follow-up actions including Sam as the DDA point of contact.

## Testing
- No automated tests were run (not applicable).


------
https://chatgpt.com/codex/tasks/task_e_68cca3d51e64832580f73c23d31601bd