### PR TITLE
Add modern corporate storytelling design blog

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -198,6 +198,25 @@
                             <a href="troubleshooting-transaction-enrichment-api.html" class="text-indigo-400 hover:underline">Read →</a>
                         </div>
                     </article>
+                    <!-- Post New -->
+                    <article class="blog-card p-6 rounded-xl">
+                        <div class="flex items-center space-x-2 mb-4">
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Design Systems</span>
+                            <span class="text-xs text-gray-500">Sep 21, 2025</span>
+                        </div>
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="modern-corporate-storytelling-web-design.html" class="hover:text-indigo-400 transition-colors">
+                                Designing a Modern Corporate Storytelling Website
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            A blueprint for turning dense strategic plans into a responsive, executive-ready narrative using progressive disclosure and card-based layouts.
+                        </p>
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-500">📚 8 min read</span>
+                            <a href="modern-corporate-storytelling-web-design.html" class="text-indigo-400 hover:underline">Read →</a>
+                        </div>
+                    </article>
                     <!-- Post -1 -->
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">

--- a/blogs/modern-corporate-storytelling-web-design.html
+++ b/blogs/modern-corporate-storytelling-web-design.html
@@ -1,0 +1,373 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Designing a Modern Corporate Storytelling Website | ChrisCruz.ai</title>
+    <meta name="description" content="A blueprint for translating complex initiatives into a Modern Corporate Storytelling web experience with progressive disclosure, strong hierarchy, and responsive cards.">
+    <meta name="keywords" content="web design, corporate storytelling, UX strategy, progressive disclosure, information architecture, Chris Cruz">
+    <meta name="author" content="Christopher Manuel Cruz-Guzman">
+    <meta property="og:title" content="Designing a Modern Corporate Storytelling Website">
+    <meta property="og:description" content="Turn dense technical plans into a guided, executive-ready website experience with modern storytelling design.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://chriscruz.ai/blogs/modern-corporate-storytelling-web-design.html">
+    <meta property="og:image" content="https://chriscruz.ai/images/modern-corporate-storytelling-web-design.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Designing a Modern Corporate Storytelling Website">
+    <meta name="twitter:description" content="Progressive disclosure, guided hierarchy, and responsive components for complex web stories.">
+    <meta name="article:published_time" content="2025-09-21T00:00:00Z">
+    <meta name="article:author" content="Christopher Manuel Cruz-Guzman">
+    <meta name="article:section" content="Design Systems">
+    <meta name="article:tag" content="web design, UX strategy, information architecture, storytelling">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #0a0a0a;
+            color: #f0f0f0;
+        }
+        .gradient-text {
+            background: linear-gradient(90deg, #4f46e5, #38bdf8, #a855f7);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .blog-content {
+            background-color: rgba(255, 255, 255, 0.02);
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(10px);
+        }
+        .principle-card {
+            background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(56, 189, 248, 0.12));
+            border: 1px solid rgba(79, 70, 229, 0.35);
+            border-radius: 1rem;
+            padding: 1.5rem;
+        }
+        .timeline-card {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(79, 70, 229, 0.15);
+            border-left: 4px solid #4f46e5;
+            border-radius: 1rem;
+            padding: 1.5rem;
+        }
+        .system-box {
+            background: linear-gradient(135deg, rgba(168, 85, 247, 0.12), rgba(14, 165, 233, 0.12));
+            border: 1px solid rgba(168, 85, 247, 0.35);
+            border-radius: 1rem;
+            padding: 1.5rem;
+        }
+        .quote-box {
+            background-color: rgba(255, 255, 255, 0.03);
+            border-left: 4px solid #38bdf8;
+        }
+        .checklist-item {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.75rem;
+        }
+        .checklist-bullet {
+            width: 1.75rem;
+            height: 1.75rem;
+            border-radius: 9999px;
+            background: linear-gradient(135deg, rgba(79, 70, 229, 0.3), rgba(168, 85, 247, 0.3));
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            color: #f0f0f0;
+        }
+    </style>
+</head>
+<body class="antialiased">
+
+    <!-- Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 bg-black/30 backdrop-blur-md">
+        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../brand-hub.html" class="text-xl font-bold tracking-tighter">ChrisCruz<span class="text-indigo-400">.ai</span></a>
+            <nav class="hidden md:flex space-x-8">
+                <a href="../brand-hub.html" class="hover:text-indigo-400 transition-colors">Empire</a>
+                <a href="../manifesto.html" class="hover:text-indigo-400 transition-colors">Manifesto</a>
+                <a href="../brand-story.html" class="hover:text-indigo-400 transition-colors">Story</a>
+                <a href="../contact.html" class="hover:text-indigo-400 transition-colors">Contact</a>
+            </nav>
+            <span class="text-xs font-semibold py-1 px-3 rounded-full bg-blue-500/20 text-blue-400 border border-blue-500/30">Design Systems</span>
+        </div>
+    </header>
+
+    <main class="pt-24">
+        <!-- Article Header -->
+        <section class="py-20 px-6">
+            <div class="container mx-auto max-w-4xl">
+                <div class="text-center mb-8">
+                    <div class="flex items-center justify-center space-x-2 mb-4">
+                        <span class="bg-gradient-to-r from-indigo-600 to-sky-600 text-white text-xs font-semibold py-1 px-3 rounded-full">Design Systems</span>
+                        <span class="text-gray-500 text-sm">September 21, 2025</span>
+                        <span class="text-gray-500 text-sm">•</span>
+                        <span class="text-gray-500 text-sm">8 min read</span>
+                    </div>
+                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-black tracking-tighter mb-6">
+                        Designing a <span class="gradient-text">Modern Corporate Storytelling</span> Website
+                    </h1>
+                    <p class="text-xl text-gray-400 max-w-3xl mx-auto leading-relaxed">
+                        When executives, engineers, and operators all need the same story, the website has to orchestrate clarity. This build turns a dense strategy plan into a guided narrative—clean visuals, progressive disclosure, and responsive cards that meet every audience where they are.
+                    </p>
+                </div>
+
+                <div class="flex items-center justify-center space-x-4 text-sm text-gray-500">
+                    <div class="flex items-center space-x-2">
+                        <div class="w-10 h-10 bg-gradient-to-r from-indigo-600 to-sky-600 rounded-full flex items-center justify-center text-white font-bold">CC</div>
+                        <span>Christopher Manuel Cruz-Guzman</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Article Content -->
+        <section class="py-20 px-6">
+            <div class="container mx-auto max-w-4xl">
+                <article class="blog-content p-8 rounded-2xl">
+
+                    <p class="text-lg text-gray-300 mb-8 leading-relaxed">
+                        The mandate was simple: communicate a multi-quarter technical transformation without overwhelming the reader. The execution demanded discipline. We leaned into a Modern Corporate Storytelling approach—controlled color, precise hierarchy, and opt-in depth. Every pixel, headline, and accordion helps someone answer, “What does this mean for me?”
+                    </p>
+
+                    <div class="quote-box p-6 mb-10 rounded-xl">
+                        <blockquote class="text-xl text-gray-200 italic">
+                            "Corporate storytelling is a choreography of information: earn attention with clarity, reward curiosity with depth." 
+                        </blockquote>
+                    </div>
+
+                    <h2 class="text-3xl font-bold mb-6 text-sky-400">Visual Language: Trust First, Then Momentum</h2>
+                    <p class="text-lg text-gray-300 mb-6 leading-relaxed">
+                        We anchored the palette in corporate indigo and slate neutrals—signal trust, minimize distraction. Accent gradients introduce momentum only when we need to emphasize decisions or metrics. The typography stack is all Inter, tuned for legibility across executive presentations, tablet stand-ups, and engineering reviews.
+                    </p>
+
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
+                        <div class="principle-card">
+                            <h3 class="font-semibold text-indigo-200 mb-2">Color Discipline</h3>
+                            <p class="text-sm text-gray-200">Primary indigo for anchors, electric sky for CTAs, muted slates for narrative text. No more than two accent hues per viewport.</p>
+                        </div>
+                        <div class="principle-card">
+                            <h3 class="font-semibold text-indigo-200 mb-2">Type Scaling</h3>
+                            <p class="text-sm text-gray-200">H1 48-64px, H2 32px, H3 22px. Body at 18px with 1.7 line-height to keep dense content breathable.</p>
+                        </div>
+                        <div class="principle-card">
+                            <h3 class="font-semibold text-indigo-200 mb-2">Iconography</h3>
+                            <p class="text-sm text-gray-200">Thin-line system icons in indigo gradients reinforce section purpose without stealing the narrative.</p>
+                        </div>
+                    </div>
+
+                    <h2 class="text-3xl font-bold mb-6 text-sky-400">Narrative Architecture: Single Column, Guided Discovery</h2>
+                    <p class="text-lg text-gray-300 mb-6 leading-relaxed">
+                        The page runs as a single-column story. We open with the executive brief, deliver the 10-pillar strategy, surface architecture diagrams, then collapse the deep dive. Each block is a self-contained card so the brain can reset between ideas.
+                    </p>
+                    <div class="system-box mb-8">
+                        <h3 class="font-semibold text-indigo-100 mb-4">Progressive Disclosure in Practice</h3>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-gray-200">
+                            <div>
+                                <p class="font-semibold text-sky-300 mb-2">Surface Layer</p>
+                                <ul class="space-y-2">
+                                    <li>• Hero summary and KPI snapshot</li>
+                                    <li>• Pillar cards with one-line promises</li>
+                                    <li>• Architecture overview with simplified diagram</li>
+                                </ul>
+                            </div>
+                            <div>
+                                <p class="font-semibold text-sky-300 mb-2">Depth Layer</p>
+                                <ul class="space-y-2">
+                                    <li>• Accordions revealing platform specifics</li>
+                                    <li>• Embedded tables for dependency matrices</li>
+                                    <li>• Download links for the technical appendix</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+
+                    <h2 class="text-3xl font-bold mb-6 text-sky-400">Component System: Cards, Timelines, Accordions</h2>
+                    <p class="text-lg text-gray-300 mb-6 leading-relaxed">
+                        Cards do the heavy lifting. Every major artifact—metrics, principles, timelines—sits inside a rounded card with consistent padding and shadow. Timelines and accordions share the same border radius so the experience feels like one cohesive design system, not stitched widgets.
+                    </p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+                        <div class="timeline-card">
+                            <h3 class="font-semibold text-indigo-200 mb-3">Narrative Timeline</h3>
+                            <ul class="space-y-3 text-sm text-gray-200">
+                                <li><span class="font-semibold text-indigo-300">0:00 - Hero</span>: Promise + KPI + CTA</li>
+                                <li><span class="font-semibold text-indigo-300">0:30 - Playbook</span>: Ten cards, each one scroll stop</li>
+                                <li><span class="font-semibold text-indigo-300">1:10 - Architecture</span>: Responsive SVG with hotspot notes</li>
+                                <li><span class="font-semibold text-indigo-300">1:40 - Deep Dive</span>: Accordion stack sorted by audience</li>
+                            </ul>
+                        </div>
+                        <div class="timeline-card">
+                            <h3 class="font-semibold text-indigo-200 mb-3">Component Tokens</h3>
+                            <ul class="space-y-3 text-sm text-gray-200">
+                                <li><span class="font-semibold text-indigo-300">Spacing</span>: 24px vertical rhythm, 32px section gutters</li>
+                                <li><span class="font-semibold text-indigo-300">Corners</span>: 20px cards, 999px pills, 12px accordions</li>
+                                <li><span class="font-semibold text-indigo-300">Shadows</span>: 0 20px 40px rgba(79, 70, 229, 0.15)</li>
+                                <li><span class="font-semibold text-indigo-300">Icons</span>: 32px line icons, gradient mask overlay</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <h2 class="text-3xl font-bold mb-6 text-sky-400">Responsive Behavior: One Codebase, Multi-Audience</h2>
+                    <p class="text-lg text-gray-300 mb-6 leading-relaxed">
+                        The single-column layout makes mobile natural. On desktop, cards snap into two-column grids for denser scanning. Accordions default open on widescreens during stakeholder reviews, but collapse on mobile to keep thumbs in control. Sticky navigation highlights the reader’s current section so nobody gets lost in the scroll.
+                    </p>
+
+                    <div class="system-box mb-10">
+                        <h3 class="font-semibold text-indigo-100 mb-4">Adaptive Patterns Checklist</h3>
+                        <div class="space-y-4 text-sm text-gray-200">
+                            <div class="checklist-item">
+                                <div class="checklist-bullet">1</div>
+                                <div><strong>Breakpoint Strategy.</strong> 100% width cards under 768px, 50/50 grids at desktop, preserving 24px gutters.</div>
+                            </div>
+                            <div class="checklist-item">
+                                <div class="checklist-bullet">2</div>
+                                <div><strong>Sticky Utilities.</strong> Header transitions from translucent black to solid slate once the hero passes 50vh.</div>
+                            </div>
+                            <div class="checklist-item">
+                                <div class="checklist-bullet">3</div>
+                                <div><strong>Motion Discipline.</strong> Micro-transitions capped at 200ms easing to reinforce modern polish without triggering motion fatigue.</div>
+                            </div>
+                            <div class="checklist-item">
+                                <div class="checklist-bullet">4</div>
+                                <div><strong>Accessibility Hooks.</strong> 4.5:1 contrast ratios, focus states on all interactive elements, and aria-expanded states on accordions.</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <h2 class="text-3xl font-bold mb-6 text-sky-400">Implementation Blueprint</h2>
+                    <p class="text-lg text-gray-300 mb-6 leading-relaxed">
+                        Design only matters if engineering can ship it. We decomposed the build into four sprints, each delivering a vertical slice so stakeholders could review progress in real time.
+                    </p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10">
+                        <div class="timeline-card">
+                            <h3 class="font-semibold text-indigo-200 mb-3">Sprint 1 • Narrative Frame</h3>
+                            <ul class="space-y-2 text-sm text-gray-200">
+                                <li>• Tailwind baseline + typography tokens</li>
+                                <li>• Hero + KPI banner + sticky nav</li>
+                                <li>• Card scaffolding with responsive gutters</li>
+                            </ul>
+                        </div>
+                        <div class="timeline-card">
+                            <h3 class="font-semibold text-indigo-200 mb-3">Sprint 2 • Content Systems</h3>
+                            <ul class="space-y-2 text-sm text-gray-200">
+                                <li>• 10-pillar card grid with iconography</li>
+                                <li>• Architecture canvas + annotation hotspots</li>
+                                <li>• Metrics card deck with gradient accents</li>
+                            </ul>
+                        </div>
+                        <div class="timeline-card">
+                            <h3 class="font-semibold text-indigo-200 mb-3">Sprint 3 • Interactive Depth</h3>
+                            <ul class="space-y-2 text-sm text-gray-200">
+                                <li>• Accordion framework with aria attributes</li>
+                                <li>• Scrollspy for section-aware navigation</li>
+                                <li>• Motion tuning + reduced motion fallback</li>
+                            </ul>
+                        </div>
+                        <div class="timeline-card">
+                            <h3 class="font-semibold text-indigo-200 mb-3">Sprint 4 • Launch Polish</h3>
+                            <ul class="space-y-2 text-sm text-gray-200">
+                                <li>• Analytics events on CTA interactions</li>
+                                <li>• Executive PDF export styling</li>
+                                <li>• Performance sweep (Lighthouse 92+)</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <h2 class="text-3xl font-bold mb-6 text-sky-400">Governance: Keep the Story Fresh</h2>
+                    <p class="text-lg text-gray-300 mb-6 leading-relaxed">
+                        A storytelling site only works if it stays current. We built a governance cadence that pairs monthly analytics reviews with quarterly content audits so the narrative evolves with the strategy.
+                    </p>
+                    <div class="system-box mb-10">
+                        <h3 class="font-semibold text-indigo-100 mb-4">Update Rituals</h3>
+                        <ul class="space-y-3 text-sm text-gray-200">
+                            <li>• <strong>Monthly:</strong> Heatmap review + CTA conversion analysis → adjust card placement.</li>
+                            <li>• <strong>Quarterly:</strong> Refresh metrics, archive deprecated initiatives, add new case studies.</li>
+                            <li>• <strong>Bi-Annual:</strong> Accessibility audit + performance tuning for new frameworks.</li>
+                            <li>• <strong>Always:</strong> Keep the copy conversational—tell the reader what changed and why it matters.</li>
+                        </ul>
+                    </div>
+
+                    <p class="text-lg text-gray-300 mb-8 leading-relaxed">
+                        The result is a website that acts like a strategic deck, an onboarding guide, and an engineering plan at the same time. It respects the reader’s time, celebrates the craft, and keeps the story moving forward.
+                    </p>
+
+                    <p class="text-lg text-gray-300">
+                        — Chris Cruz
+                    </p>
+
+                </article>
+            </div>
+        </section>
+
+        <!-- Related Posts -->
+        <section class="py-20 px-6 bg-white/5">
+            <div class="container mx-auto max-w-4xl">
+                <h2 class="text-3xl font-bold text-center mb-12">Related Design & Strategy Notes</h2>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                    <div class="blog-content p-6 rounded-xl">
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="ai-powered-nudge-engine-for-social-dining.html" class="hover:text-indigo-400 transition-colors">
+                                The Anatomy of an AI-Powered Nudge Engine
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            How vector search, RAG messaging, and service design converge to keep product flows feeling effortless.
+                        </p>
+                        <a href="ai-powered-nudge-engine-for-social-dining.html" class="text-indigo-400 hover:underline text-sm">Design the Nudge Engine →</a>
+                    </div>
+
+                    <div class="blog-content p-6 rounded-xl">
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="strategic-transaction-history-architecture.html" class="hover:text-indigo-400 transition-colors">
+                                Strategic Architectural Decision: Option B for Transaction History
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            A high-stakes architecture call that blends platform constraints, executive storytelling, and delivery rigor.
+                        </p>
+                        <a href="strategic-transaction-history-architecture.html" class="text-indigo-400 hover:underline text-sm">Review the Architecture →</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Newsletter Signup -->
+        <section class="py-20 px-6">
+            <div class="container mx-auto max-w-2xl text-center">
+                <h2 class="text-3xl font-bold mb-4">Stay Ahead of the Design Loop</h2>
+                <p class="text-lg text-gray-400 mb-8">Get weekly notes on design systems, AI strategy, and modern storytelling straight from the build floor.</p>
+
+                <div class="blog-content p-8 rounded-2xl">
+                    <form class="space-y-4">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <input type="text" placeholder="First Name" class="w-full px-4 py-3 rounded-lg bg-gray-800 border border-gray-700 text-white focus:outline-none focus:border-indigo-500" required>
+                            <input type="text" placeholder="Last Name" class="w-full px-4 py-3 rounded-lg bg-gray-800 border border-gray-700 text-white focus:outline-none focus:border-indigo-500" required>
+                        </div>
+                        <input type="email" placeholder="Email Address" class="w-full px-4 py-3 rounded-lg bg-gray-800 border border-gray-700 text-white focus:outline-none focus:border-indigo-500" required>
+
+                        <button type="submit" class="w-full bg-gradient-to-r from-indigo-600 to-sky-600 hover:from-indigo-700 hover:to-sky-700 text-white py-4 rounded-lg font-semibold text-lg transition-all duration-300 transform hover:scale-105">
+                            Join the Design Dispatch
+                        </button>
+                    </form>
+
+                    <p class="text-xs text-gray-500 mt-4">No spam. Just systems, stories, and strategies that ship.</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-white/10 py-8 px-6">
+        <div class="container mx-auto text-center text-gray-500">
+            <p class="font-bold text-lg tracking-tighter">ChrisCruz<span class="text-indigo-400">.ai</span></p>
+            <p class="text-sm">&copy; 2025. Empire Building Blog. All Rights Reserved.</p>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -361,6 +361,17 @@
             <div class="writing-grid">
                 <article class="writing-card">
                     <div class="writing-meta">
+                        <span class="writing-category">Design Systems</span>
+                        <span class="writing-date">September 21, 2025</span>
+                    </div>
+                    <h3 class="writing-title">Designing a Modern Corporate Storytelling Website</h3>
+                    <p class="writing-excerpt">
+                        A modern storytelling blueprint that translates complex initiatives into a guided web experience with progressive disclosure, sticky navigation, and responsive cards.
+                    </p>
+                    <a href="blogs/modern-corporate-storytelling-web-design.html" class="writing-link">Build the Narrative →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
                         <span class="writing-category">Quarterly Planning</span>
                         <span class="writing-date">September 20, 2025</span>
                     </div>


### PR DESCRIPTION
## Summary
- add a modern corporate storytelling design blog post detailing layout, component, and governance guidance
- link the new article from the homepage writing section for quick discovery
- surface the post in the blog index alongside existing entries

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68ccc1dd12608325942913fdde5596ca