### PR TITLE
Replace home work section with atomic notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,57 +180,69 @@
     <section id="work" class="work">
         <div class="container">
             <div class="section-header">
-                <h2 class="section-title">Current Work</h2>
-                <p class="section-subtitle">Leading AI innovation in financial services while building the future of productivity.</p>
+                <h2 class="section-title">Atomic Notes</h2>
+                <p class="section-subtitle">
+                    Quick-reference dashboards powering the DDA Going Primary mission.
+                    <a href="/notes/index.html" class="writing-link">Browse the full atomic notes index →</a>
+                </p>
             </div>
             <div class="work-grid">
                 <div class="work-card">
                     <div class="work-card-header">
-                        <div class="work-logo">🏦</div>
-                        <h3 class="work-title">J.P. Morgan</h3>
-                        <p class="work-role">AI & Financial Infrastructure</p>
+                        <div class="work-logo">🧭</div>
+                        <h3 class="work-title">Data Consistency Signal Stack</h3>
+                        <p class="work-role">Atomic Note · Updated Sep 15, 2025</p>
                     </div>
                     <p class="work-description">
-                        Leading strategic initiatives including DDA Going Primary and AI-powered enrichment models 
-                        for transaction clarity. Managing teams and driving digital transformation in banking.
+                        Guarantees 99%+ accuracy, 1-second SLA adherence, and 99.99% uptime by harmonizing
+                        GATCHT3, ESDD, FAP, and Transaction History API streams inside the ODS.
                     </p>
                     <div class="work-tags">
-                        <span class="tag">AI/ML</span>
-                        <span class="tag">Team Leadership</span>
-                        <span class="tag">Financial Tech</span>
+                        <span class="tag">Data Integrity</span>
+                        <span class="tag">SLA</span>
+                        <span class="tag">Observability</span>
                     </div>
+                    <p class="work-description">
+                        <a href="/notes/data-consistency-dashboard-note.html" class="writing-link">Open note →</a>
+                    </p>
                 </div>
                 <div class="work-card">
                     <div class="work-card-header">
-                        <div class="work-logo">🤖</div>
-                        <h3 class="work-title">Cruz AI</h3>
-                        <p class="work-role">Founder & CEO</p>
+                        <div class="work-logo">🛰️</div>
+                        <h3 class="work-title">Event Store Reconciliation Control</h3>
+                        <p class="work-role">Atomic Note · Updated Sep 15, 2025</p>
                     </div>
                     <p class="work-description">
-                        Building an AI agency that consults and creates AI solutions for businesses. 
-                        Democratizing AI access and helping organizations leverage technology for growth.
+                        Tracks producer-consumer gaps across DDA, Cards, and shared event metrics, translating
+                        latency breaches into tangible customer and operational impacts for rapid mitigation.
                     </p>
                     <div class="work-tags">
-                        <span class="tag">AI Consulting</span>
-                        <span class="tag">Entrepreneurship</span>
-                        <span class="tag">Innovation</span>
+                        <span class="tag">Reconciliation</span>
+                        <span class="tag">Cross-Platform</span>
+                        <span class="tag">Signal Health</span>
                     </div>
+                    <p class="work-description">
+                        <a href="/notes/event-store-reconciliation-dashboard-note.html" class="writing-link">Open note →</a>
+                    </p>
                 </div>
                 <div class="work-card">
                     <div class="work-card-header">
-                        <div class="work-logo">📚</div>
-                        <h3 class="work-title">Content Creation</h3>
-                        <p class="work-role">Author & Educator</p>
+                        <div class="work-logo">⚡</div>
+                        <h3 class="work-title">Latency Dashboard Readiness</h3>
+                        <p class="work-role">Atomic Note · Updated Sep 15, 2025</p>
                     </div>
                     <p class="work-description">
-                        Writing a book on Apple Shortcuts & AI automation, sharing insights on productivity, 
-                        and building educational content around AI and personal development.
+                        Focuses on sub-500ms API response times, TH API field remediation, and JMeter validation
+                        across both clusters to unlock a confident go-live window.
                     </p>
                     <div class="work-tags">
-                        <span class="tag">Writing</span>
-                        <span class="tag">Education</span>
-                        <span class="tag">Automation</span>
+                        <span class="tag">Performance</span>
+                        <span class="tag">Readiness</span>
+                        <span class="tag">Instrumentation</span>
                     </div>
+                    <p class="work-description">
+                        <a href="/notes/latency-dashboard-note.html" class="writing-link">Open note →</a>
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the home "Current Work" section with an "Atomic Notes" introduction linked to the full notes index
- showcase three key DDA dashboard atomic notes with updated copy, tags, and direct links

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ccd2d472c08325af3bb9a2b0b85ff8