### PR TITLE
Add Cuculi notification microservices blog

### DIFF
--- a/blogs/cuculi-notification-ai-microservices.html
+++ b/blogs/cuculi-notification-ai-microservices.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cuculi Notification Architecture: AI Microservices for Precision Nudges - Chris Cruz</title>
+    <meta name="description" content="Designing a minimalist, highly-organized AI microservices stack for Cuculi's psychology-driven notifications." />
+    <meta name="keywords" content="Cuculi, AI microservices, notification architecture, Flask, AWS Lambda, MongoDB, vector search, LLM agents" />
+    <meta name="author" content="Chris Cruz" />
+    <meta property="og:title" content="Cuculi Notification Architecture: AI Microservices for Precision Nudges" />
+    <meta property="og:description" content="A professional blueprint for building Flask and Lambda-based LLM notification agents with MongoDB vector search." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://chriscruz.ai/blogs/cuculi-notification-ai-microservices.html" />
+    <meta property="og:image" content="https://chriscruz.ai/images/cuculi-notification-agents-preview.jpg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Cuculi Notification Architecture: AI Microservices for Precision Nudges" />
+    <meta name="twitter:description" content="Designing AI notification agents with RESTful microservices, vector search, and psychology-informed prompts." />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #f5f7fa;
+            color: #1f2933;
+        }
+        .prose p {
+            margin-bottom: 1.25rem;
+            line-height: 1.7;
+        }
+        .prose ul, .prose ol {
+            margin-bottom: 1.5rem;
+        }
+        .gradient-bar {
+            height: 4px;
+            width: 60px;
+            background: linear-gradient(90deg, #0f172a, #2563eb);
+            border-radius: 9999px;
+        }
+        code {
+            font-family: 'JetBrains Mono', monospace;
+        }
+        .table-wrapper {
+            overflow-x: auto;
+        }
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+        th, td {
+            border: 1px solid #e2e8f0;
+            padding: 1rem;
+            text-align: left;
+            vertical-align: top;
+        }
+        th {
+            background-color: #eff4ff;
+            color: #1e3a8a;
+            font-weight: 600;
+        }
+        td {
+            background-color: #ffffff;
+        }
+        .callout {
+            border-left: 4px solid #2563eb;
+            background-color: #ffffff;
+            padding: 1.5rem;
+            border-radius: 0.75rem;
+            box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+        }
+        .reference-list li {
+            margin-bottom: 0.5rem;
+        }
+    </style>
+</head>
+<body class="antialiased">
+    <div class="max-w-5xl mx-auto px-6 sm:px-10 py-10 md:py-16">
+        <nav class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-12 text-sm font-semibold text-slate-600">
+            <a href="../index.html" class="inline-flex items-center gap-2 hover:text-slate-900 transition-colors">
+                <span aria-hidden="true">←</span>
+                <span>Back to Home</span>
+            </a>
+            <a href="index.html" class="inline-flex items-center gap-2 hover:text-slate-900 transition-colors">
+                <span>Browse All Articles</span>
+                <span aria-hidden="true">→</span>
+            </a>
+        </nav>
+
+        <header class="bg-white rounded-3xl shadow-xl border border-slate-200 p-8 md:p-12 mb-16">
+            <div class="gradient-bar mb-6"></div>
+            <p class="uppercase tracking-[0.3em] text-xs text-slate-500 mb-4">AI Notification Architecture</p>
+            <h1 class="text-4xl md:text-5xl font-extrabold text-slate-900 leading-tight mb-6">
+                Precision Nudges: Designing LLM Microservices for Cuculi's Notification Engine
+            </h1>
+            <p class="text-lg md:text-xl text-slate-600 max-w-3xl">
+                A minimalist, modern operating model for orchestrating personality-driven AI agents that send psychology-backed notifications at scale.
+            </p>
+        </header>
+
+        <article class="prose max-w-none">
+            <p class="text-xl font-semibold text-slate-800">
+                as we kick off notification project as part of my mission to implement AI as part of Cuculi, we need to work together to build AI Micro-Services to be leveraged by Engineers for sending out the nudge notifications. I want this program to feel like a shared moonshot—an invitation to reimagine how every push we send helps members feel understood, welcomed, and inspired to take part.
+            </p>
+
+            <section class="mt-12">
+                <h2 class="text-3xl font-bold text-slate-900 mb-4">Beginning: Define the Intent and the Standard</h2>
+                <div class="callout mb-6">
+                    <p class="font-semibold text-slate-900">North Star</p>
+                    <p class="text-slate-600 mb-0">Every notification should compress intelligence, context, and urgency into fewer than 140 characters while feeling unmistakably "Cuculi." That means consistent tone systems, audit-ready telemetry, and end-to-end observability from prompt to delivery.</p>
+                </div>
+                <p>
+                    We start by codifying what an ideal nudge looks like: clear call-to-action, direct reference to the member’s latest behavior, and a concise psychological trigger. By treating each LLM-powered microservice as a distinct product—with its own goal, guardrails, and success metrics—we preserve creative range while maintaining enterprise-grade accountability.
+                </p>
+                <p>
+                    The organizational frame leans on <a href="https://aws.amazon.com/blogs/opensource/deploying-python-flask-microservices-to-aws-using-open-source-tools/" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">AWS guidance for containerized Flask microservices</a> and <a href="https://aws.amazon.com/blogs/compute/effectively-building-ai-agents-on-aws-serverless/" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">serverless agent orchestration strategies</a>. These patterns give us the routing discipline and scaling guardrails we need before the first prompt is even drafted.
+                </p>
+            </section>
+
+            <section class="mt-12">
+                <h2 class="text-3xl font-bold text-slate-900 mb-4">Middle: Architect the Agent Mesh</h2>
+                <p>
+                    The technical system is a mesh of RESTful agents, each deployed as either a Flask Blueprint or an AWS Lambda function, fronted by a shared API gateway. Every service loads its own prompt template, persona, and guardrail logic at boot. MongoDB Atlas handles primary storage, giving each agent a low-latency path to user, event, and embedding collections. Vector search becomes the personalization backbone, aligning with <a href="https://www.mongodb.com/docs/atlas/architecture/current/solutions-library/media-personalization/" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">MongoDB’s reference architecture for media personalization</a> and <a href="https://www.mongodb.com/products/platform/atlas-vector-search" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">Atlas Vector Search</a> best practices.
+                </p>
+                <p>
+                    To uphold transparency, each response is templated: a single notification string with a CTA, purposeful psychology cue, and no hallucinated claims. Analytics logging captures the prompt, context payload, completion tokens, and downstream delivery status for continuous tuning—borrowing lessons from <a href="https://www.braze.com/resources/articles/push-notifications-best-practices" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">push notification playbooks</a> and <a href="https://www.joinglyph.com/blog/ai-voice-and-llm-to-supercharge-marketing" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">AI-enabled marketing experiments</a>.
+                </p>
+
+                <div class="table-wrapper mt-8 mb-12">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Service</th>
+                                <th>Endpoint</th>
+                                <th>Input / Output</th>
+                                <th>Key Internal Logic</th>
+                                <th>Prompt Personality Highlights</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><strong>Intent Nudge</strong></td>
+                                <td><code>/api/intent-nudge</code></td>
+                                <td>In: <code>user_id</code>, <code>recent_activity</code><br>Out: Notification text &lt;140 chars</td>
+                                <td>Classifies member momentum, selects nudge type (first-touch, follow-up, or alternative) using recency and sentiment scores.</td>
+                                <td>Coach-like, direct, and time-bound. Applies scarcity cues when activity dips.</td>
+                            </tr>
+                            <tr>
+                                <td><strong>User Event Recommender</strong></td>
+                                <td><code>/api/recommend-event</code></td>
+                                <td>In: <code>user_id</code>, profile vector<br>Out: Event invite message</td>
+                                <td>Runs similarity search on event embeddings, cross-checks social graph proximity, then frames invite with social proof.</td>
+                                <td>Conversational and enthusiastic friend persona anchoring on shared interests.</td>
+                            </tr>
+                            <tr>
+                                <td><strong>Event-to-User Matcher</strong></td>
+                                <td><code>/api/event-target</code></td>
+                                <td>In: <code>event_id</code><br>Out: Batch of {user_id, message}</td>
+                                <td>Generates ranked audience list with fairness weighting, ensuring a balance of loyalists and explorers.</td>
+                                <td>High-energy promoter; emphasizes exclusivity without overpromising.</td>
+                            </tr>
+                            <tr>
+                                <td><strong>Profile Completion Guide</strong></td>
+                                <td><code>/api/complete-profile</code></td>
+                                <td>In: <code>user_id</code>, profile status<br>Out: Motivational reminder</td>
+                                <td>Evaluates missing profile fields, surfaces nearest unlocked benefits, and personalizes reinforcement cue.</td>
+                                <td>Encouraging mentor tone centered on unlocking value and belonging.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <p>
+                    We deploy via container images or Lambda layers, guided by <a href="https://dev.to/aws-builders/from-docker-to-lambda-an-aws-admins-journey-into-python-applications-24e4" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">Docker-to-Lambda transition playbooks</a> and <a href="https://dev.to/amolo/how-to-build-microservices-with-fauna-python-flask-and-deploy-to-vercel-4k19" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">Flask microservice deployment tutorials</a>. Observability hooks—structured logging, OpenTelemetry traces, and event-based alerts—flow into a central quality hub so our engineers can iterate safely.
+                </p>
+
+                <div class="bg-white border border-slate-200 rounded-2xl p-6 md:p-8 shadow-lg mt-10">
+                    <h3 class="text-2xl font-semibold text-slate-900 mb-4">Prompt Blueprint</h3>
+                    <p class="text-slate-600 mb-4">Each agent maintains a system prompt like the snippet below to keep outputs concise, actionable, and psychologically tuned.</p>
+                    <pre class="bg-slate-900 text-slate-100 p-4 rounded-xl text-sm overflow-x-auto"><code>You are the Intent Nudge agent for Cuculi.
+- Output a single push notification under 140 characters.
+- Reference the user's latest dining signal.
+- End with one CTA.
+- Use urgency or scarcity only when activity has dipped.
+- Never fabricate people, places, or rewards.
+Context: {{recent_activity_snapshot}}
+Goal: Drive the next RSVP within 24 hours.</code></pre>
+                </div>
+            </section>
+
+            <section class="mt-12">
+                <h2 class="text-3xl font-bold text-slate-900 mb-4">End: Orchestrate, Measure, and Keep Human in the Loop</h2>
+                <p>
+                    Orchestration hinges on a lightweight router that selects the right agent, validates payloads, and manages retries. Slow LLM calls route through async workers powered by <a href="https://aws.amazon.com/blogs/compute/effectively-building-ai-agents-on-aws-serverless/" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">serverless queues and Step Functions</a>. Delivery channels—FCM, APNs, SMS via Twilio—feed engagement metrics back into a reinforcement loop so prompt templates evolve with real outcomes.
+                </p>
+                <p>
+                    MongoDB vector search results, open rates, and RSVP conversions roll into a living scorecard. Weekly reviews pair the data with qualitative readouts from community leads, making sure the system stays empathetic, not just efficient. Inspiration from <a href="https://insight7.io/llms-that-coach-reps-on-personalization-techniques-in-sales-emails/" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">coaching-style LLM programs</a> reminds us that tone and timing can be coached just like a sales team.
+                </p>
+                <ul class="list-disc pl-6 text-slate-700">
+                    <li><strong>Shared dashboards</strong> clarify which agent version drove lifts, aligning product, engineering, and community teams on reality.</li>
+                    <li><strong>Prompt retrospectives</strong> treat each iteration like a product release—documented diffs, hypothesis tracking, and QA sign-off.</li>
+                    <li><strong>Human escalation paths</strong> keep a concierge or community manager ready to intervene whenever the AI needs a human touch.</li>
+                </ul>
+                <p>
+                    The outcome: an elegant, modular notification stack that feels personal, scales responsibly, and keeps our teams collaborating. This is how we transform nudges into genuine invitations.
+                </p>
+            </section>
+
+            <section class="mt-16">
+                <h2 class="text-2xl font-semibold text-slate-900 mb-3">Key Resources to Dive Deeper</h2>
+                <ul class="reference-list list-disc pl-6 text-slate-700">
+                    <li><a href="https://dev.to/aarushikansal/superpower-your-push-notifications-with-ai-348l" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">Superpower Your Push Notifications with AI</a> — frameworks for urgency and clarity in copywriting.</li>
+                    <li><a href="https://www.mongodb.com/company/bloginnovationai-powered-media-personalization-mongodb-vector-search" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">AI-Powered Personalization with MongoDB Vector Search</a> — deep dive on embeddings and segmentation.</li>
+                    <li><a href="https://aws.amazon.com/blogs/compute/effectively-building-ai-agents-on-aws-serverless/" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">Effectively Building AI Agents on AWS Serverless</a> — orchestration best practices for LLM workloads.</li>
+                    <li><a href="https://arxiv.org/html/2411.00027" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline">Frontiers in Notification Science</a> — emerging research on multi-agent personalization loops.</li>
+                </ul>
+            </section>
+        </article>
+    </div>
+</body>
+</html>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -92,23 +92,23 @@
                 <div class="max-w-4xl mx-auto">
                     <div class="blog-card p-8 rounded-2xl">
                         <div class="flex items-center space-x-2 mb-4">
-                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Quality Engineering</span>
-                            <span class="text-xs text-gray-500">Mar 24, 2025</span>
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Notification Architecture</span>
+                            <span class="text-xs text-gray-500">Sep 22, 2025</span>
                         </div>
                         <h3 class="text-2xl md:text-3xl font-bold mb-4">
-                            <a href="end-to-end-and-api-testing-for-etd.html" class="hover:text-indigo-400 transition-colors">
-                                End-to-End and API Testing for ETD
+                            <a href="cuculi-notification-ai-microservices.html" class="hover:text-indigo-400 transition-colors">
+                                Precision Nudges: Designing LLM Microservices for Cuculi
                             </a>
                         </h3>
                         <p class="text-gray-300 mb-6 leading-relaxed">
-                            A production-grade QA blueprint covering layered API validation, merchant enrichment, mobile UX, and compliance to deliver a sub-three-second Enhanced Transaction Details experience.
+                            Architect a light-theme, psychology-aware notification program using Flask or Lambda microservices, MongoDB vector search, and disciplined prompt design that keeps Cuculi members engaged.
                         </p>
                         <div class="flex items-center justify-between">
                             <div class="flex items-center space-x-4 text-sm text-gray-400">
-                                <span>📚 9 min read</span>
-                                <span>🧪 Release Readiness</span>
+                                <span>📚 8 min read</span>
+                                <span>🤖 AI Microservices</span>
                             </div>
-                            <a href="end-to-end-and-api-testing-for-etd.html" class="text-indigo-400 hover:text-indigo-300 font-semibold">
+                            <a href="cuculi-notification-ai-microservices.html" class="text-indigo-400 hover:text-indigo-300 font-semibold">
                                 Read Full Post →
                             </a>
                         </div>
@@ -180,6 +180,24 @@
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                    <article class="blog-card p-6 rounded-xl">
+                        <div class="flex items-center space-x-2 mb-4">
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Notification Architecture</span>
+                            <span class="text-xs text-gray-500">Sep 22, 2025</span>
+                        </div>
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="cuculi-notification-ai-microservices.html" class="hover:text-indigo-400 transition-colors">
+                                Precision Nudges: Designing LLM Microservices for Cuculi
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            Blueprint a network of persona-driven LLM agents, API gateway routing, and MongoDB vector search to ship psychology-backed push notifications that convert.
+                        </p>
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-500">📚 8 min read</span>
+                            <a href="cuculi-notification-ai-microservices.html" class="text-indigo-400 hover:underline">Read →</a>
+                        </div>
+                    </article>
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Integration</span>

--- a/index.html
+++ b/index.html
@@ -392,6 +392,18 @@
             <div class="writing-grid">
                 <article class="writing-card">
                     <div class="writing-meta">
+                        <span class="writing-category">AI Notification Architecture</span>
+                        <span class="writing-date">September 22, 2025</span>
+                    </div>
+                    <h3 class="writing-title">Precision Nudges: Designing LLM Microservices for Cuculi</h3>
+                    <p class="writing-excerpt">
+                        A minimalist, professional blueprint for orchestrating Flask and Lambda LLM agents, MongoDB vector search,
+                        and psychology-driven prompts that scale Cuculi's notification program with confidence.
+                    </p>
+                    <a href="blogs/cuculi-notification-ai-microservices.html" class="writing-link">Design the Agent Mesh →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
                         <span class="writing-category">Design Systems</span>
                         <span class="writing-date">September 21, 2025</span>
                     </div>


### PR DESCRIPTION
## Summary
- add a minimalist, light-theme blog detailing the Cuculi AI notification microservices architecture with linked resources
- feature the new article on the home page writing section and blog index featured/latest listings

## Testing
- no automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d0077e7e948325b857660dd613c4b3