### PR TITLE
Add Life OS architecture blog and update blog index

### DIFF
--- a/blogs/beyond-the-to-do-list-life-operating-system.html
+++ b/blogs/beyond-the-to-do-list-life-operating-system.html
@@ -1,0 +1,580 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Beyond the To-Do List: Architecting a Life Operating System That Actually Works | ChrisCruz.ai</title>
+    <meta name="description" content="Blend GTD, PARA, timeboxing, and energy management principles to build a flexible Life OS. Explore routines, visual frameworks, and a supporting app concept called Fulcrum."/>
+    <meta name="keywords" content="Life OS, productivity systems, GTD, PARA method, timeboxing, biological prime time, Fulcrum app, Chris Cruz"/>
+    <meta name="author" content="Christopher Manuel Cruz-Guzman"/>
+    <meta property="og:title" content="Beyond the To-Do List: Architecting a Life Operating System That Actually Works"/>
+    <meta property="og:description" content="Design a Life Operating System that supports clarity, energy, and resilience by combining the best productivity frameworks."/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:url" content="https://chriscruz.ai/blogs/beyond-the-to-do-list-life-operating-system.html"/>
+    <meta property="og:image" content="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1400&q=80"/>
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:title" content="Beyond the To-Do List: Architecting a Life Operating System That Actually Works"/>
+    <meta name="twitter:description" content="Move from chaos to clarity with a Life Operating System tailored to your brain and energy."/>
+    <meta name="twitter:image" content="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1400&q=80"/>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #F0F8FF;
+            color: #1F2937;
+        }
+        .prose p {
+            margin-bottom: 1.25rem;
+        }
+        .section-shell {
+            background-color: #FFFFFF;
+            border-radius: 1rem;
+            box-shadow: 0 20px 45px rgba(176, 196, 222, 0.25);
+        }
+        .tag-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.4rem 0.8rem;
+            border-radius: 9999px;
+            background-color: rgba(70, 130, 180, 0.15);
+            color: #1F4A6E;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .accent-text {
+            color: #4682B4;
+        }
+        .insight-card {
+            background-color: #FFFFFF;
+            border: 1px solid #D6E4FF;
+            border-radius: 0.9rem;
+            padding: 1.5rem;
+            box-shadow: 0 12px 30px rgba(70, 130, 180, 0.12);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .insight-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 18px 38px rgba(70, 130, 180, 0.18);
+        }
+        .chart-container {
+            position: relative;
+            width: 100%;
+            max-width: 640px;
+            margin-left: auto;
+            margin-right: auto;
+            height: 320px;
+            max-height: 420px;
+        }
+        @media (min-width: 768px) {
+            .chart-container {
+                height: 400px;
+            }
+        }
+        .flowchart-node {
+            border: 2px solid #B0C4DE;
+            background-color: #FFFFFF;
+            padding: 1.25rem;
+            border-radius: 0.75rem;
+            text-align: center;
+            box-shadow: 0 6px 14px rgba(70, 130, 180, 0.12);
+            flex-grow: 1;
+        }
+        .flowchart-connector {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-grow: 0;
+            color: #4682B4;
+            font-weight: 700;
+        }
+        .flowchart-connector::after {
+            content: '→';
+            font-size: 2.25rem;
+        }
+        @media (max-width: 767px) {
+            .flowchart-connector {
+                padding: 0.5rem 0;
+            }
+            .flowchart-connector::after {
+                content: '↓';
+            }
+        }
+        .feature-card {
+            background-color: #FFFFFF;
+            border-radius: 0.9rem;
+            border: 1px solid #D6E4FF;
+            padding: 1.75rem;
+            box-shadow: 0 8px 22px rgba(70, 130, 180, 0.12);
+        }
+    </style>
+</head>
+<body class="antialiased">
+
+    <header class="bg-[#4682B4] text-white py-12 md:py-16 px-6">
+        <div class="max-w-5xl mx-auto text-center">
+            <div class="flex justify-center mb-4">
+                <span class="tag-pill bg-white/20 text-white">LifeOS Strategy</span>
+            </div>
+            <h1 class="text-4xl md:text-5xl font-extrabold leading-tight mb-4">Beyond the To-Do List: Architecting a Life Operating System That Actually Works</h1>
+            <p class="text-lg md:text-xl max-w-3xl mx-auto text-blue-50">Stop importing rigid productivity templates and start designing a responsive system that thinks like you do. Here’s how to blend proven frameworks into a Life OS that honors your energy, your commitments, and your ambitions.</p>
+        </div>
+    </header>
+
+    <main class="max-w-6xl mx-auto px-4 md:px-8 -mt-12 md:-mt-16 pb-20">
+        <article class="section-shell p-6 md:p-10 space-y-16">
+
+            <section id="system-architect-mindset" class="prose max-w-none">
+                <h2 class="text-3xl font-bold accent-text mb-4">You Are the Architect, Not the App Store</h2>
+                <p>Every time a new planner or methodology promises to fix everything, it secretly assumes your life is predictable. Real life is anything but. Your job is not to squeeze yourself into someone else’s playbook—it’s to be the architect who selects the right beams, insulation, and fixtures for the house you actually live in. Think of your Life Operating System as custom software built for your personal hardware.</p>
+                <p>The goal of this piece is to map that build. We’ll start with the core frameworks that give structure, bake in the principles that keep the system humane, and finish with routines that keep it alive. Then we’ll zoom out with a visual dashboard and introduce Fulcrum—a concept for the software that could support it.</p>
+            </section>
+
+            <section id="frameworks" class="space-y-8">
+                <div class="text-center max-w-3xl mx-auto">
+                    <h2 class="text-3xl font-bold accent-text mb-4">Part 1: The Frameworks — Your Structural Blueprint</h2>
+                    <p class="text-lg text-gray-600">Different types of work demand different operating rules. Combining the best pieces of proven systems creates a resilient foundation.</p>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    <div class="insight-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">GTD (Getting Things Done)</h3>
+                        <p class="text-gray-600">Build a trusted inbox for every open loop so your brain is free to problem-solve instead of playing storage locker.</p>
+                        <ul class="list-disc list-inside text-sm text-gray-500 space-y-2 mt-4">
+                            <li>Perform regular mind sweeps to capture loose ends.</li>
+                            <li>Clarify the very next physical action before filing anything away.</li>
+                            <li>Use the two-minute rule to vaporize trivial tasks immediately.</li>
+                        </ul>
+                    </div>
+                    <div class="insight-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">P.A.R.A. Method</h3>
+                        <p class="text-gray-600">Organize digital material by actionability instead of topic so projects are easy to execute and archives stay clean.</p>
+                        <ul class="list-disc list-inside text-sm text-gray-500 space-y-2 mt-4">
+                            <li>Projects: Short-term outcomes with clear deadlines.</li>
+                            <li>Areas: Ongoing responsibilities that require maintenance.</li>
+                            <li>Resources &amp; Archives: Curate research, inspiration, and finished work without clutter.</li>
+                        </ul>
+                    </div>
+                    <div class="insight-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">Timeboxing</h3>
+                        <p class="text-gray-600">Treat time like the finite resource it is. Scheduling blocks converts wishful thinking into visible commitments.</p>
+                        <ul class="list-disc list-inside text-sm text-gray-500 space-y-2 mt-4">
+                            <li>Assign calendar blocks to your top one to three priorities.</li>
+                            <li>Anchor deep work inside your Biological Prime Time.</li>
+                            <li>Constrain tasks so Parkinson’s Law works for you, not against you.</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <section id="principles" class="space-y-8">
+                <div class="text-center max-w-3xl mx-auto">
+                    <h2 class="text-3xl font-bold accent-text mb-4">Part 2: The Principles — Philosophy Over Perfection</h2>
+                    <p class="text-lg text-gray-600">Structure without soul collapses. These principles keep the system generous enough to survive real life.</p>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    <div class="insight-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">Be Holistic</h3>
+                        <p class="text-gray-600">Work, health, relationships, and creativity all matter. Review them together so the system reflects the whole human.</p>
+                        <ul class="list-disc list-inside text-sm text-gray-500 space-y-2 mt-4">
+                            <li>Run a monthly Wheel of Life or “Lifescan.”</li>
+                            <li>Ensure each PARA Area has explicit standards.</li>
+                            <li>Protect white space for recovery and connection.</li>
+                        </ul>
+                    </div>
+                    <div class="insight-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">Manage Energy</h3>
+                        <p class="text-gray-600">Time is meaningless without the energy to use it. Align creative pushes with your natural peaks and defend Move/Think/Rest cycles.</p>
+                        <ul class="list-disc list-inside text-sm text-gray-500 space-y-2 mt-4">
+                            <li>Track energy for two to three weeks to find your prime time.</li>
+                            <li>Schedule movement and recovery blocks like any meeting.</li>
+                            <li>Respect the fact that focus is a renewable—but limited—resource.</li>
+                        </ul>
+                    </div>
+                    <div class="insight-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">Design for Resilience</h3>
+                        <p class="text-gray-600">You will miss a day. Build a system that forgives lapses and makes it easy to restart without shame.</p>
+                        <ul class="list-disc list-inside text-sm text-gray-500 space-y-2 mt-4">
+                            <li>Favor “daily-ish” habits over brittle streaks.</li>
+                            <li>Use templates for bounce-back reviews after chaotic weeks.</li>
+                            <li>Keep protocols light enough to rebuild in under an hour.</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <section id="routines" class="space-y-8">
+                <div class="text-center max-w-3xl mx-auto">
+                    <h2 class="text-3xl font-bold accent-text mb-4">Part 3: The Steps &amp; Routines — Keep the System Alive</h2>
+                    <p class="text-lg text-gray-600">Think of these cadences as the heartbeat of your Life OS. They translate frameworks and principles into daily movement.</p>
+                </div>
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                    <div class="insight-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">Daily Triage &amp; Execution</h3>
+                        <ul class="list-disc list-inside text-sm text-gray-500 space-y-2">
+                            <li>Morning startup: scan the calendar, identify one to three needle-moving outcomes, and timebox them.</li>
+                            <li>During the day: apply the two-minute rule and capture unexpected tasks immediately.</li>
+                            <li>Evening shutdown: clear inboxes and set intentions for tomorrow to avoid decision fatigue.</li>
+                        </ul>
+                    </div>
+                    <div class="insight-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">Weekly Review</h3>
+                        <ul class="list-disc list-inside text-sm text-gray-500 space-y-2">
+                            <li>Get clear by processing every inbox back to zero.</li>
+                            <li>Get current by reviewing projects, waiting-fors, and the upcoming calendar.</li>
+                            <li>Get creative by scanning someday/maybe ideas and choosing the week’s emphasis.</li>
+                        </ul>
+                    </div>
+                    <div class="insight-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">Monthly Check-In</h3>
+                        <ul class="list-disc list-inside text-sm text-gray-500 space-y-2">
+                            <li>Review progress on medium-term goals and PARA Areas.</li>
+                            <li>Run a Lifescan to rate satisfaction across health, finances, relationships, and more.</li>
+                            <li>Select one or two focus areas for the upcoming month and book the first step.</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <section id="life-os-visualized" class="space-y-12">
+                <div class="text-center max-w-3xl mx-auto">
+                    <h2 class="text-3xl font-bold accent-text mb-4">Visualizing a Balanced Life OS</h2>
+                    <p class="text-lg text-gray-600">Use these visuals as a diagnostic dashboard. They capture how modern frameworks, cadences, and energy-aware scheduling come together in practice.</p>
+                </div>
+
+                <section id="evolution" class="bg-white rounded-lg shadow-md p-6 md:p-8">
+                    <h3 class="text-3xl font-bold text-[#4682B4] mb-4 text-center">The Evolution of Productivity</h3>
+                    <p class="text-center max-w-3xl mx-auto mb-8">Modern productivity is shifting from rigid, structure-heavy systems to flexible, well-being-focused frameworks. The new approach prioritizes energy and alignment over simply getting more done, recognizing that sustainability is the ultimate goal.</p>
+                    <div class="chart-container">
+                        <canvas id="frameworksComparisonChart"></canvas>
+                    </div>
+                    <p class="text-center text-sm text-gray-600 mt-4">This chart compares traditional frameworks like GTD against newer, more holistic systems. Newer frameworks show greater flexibility and a stronger focus on energy management, making them more adaptable to the complexities of modern life and less prone to burnout.</p>
+                </section>
+
+                <section id="framework-menu" class="space-y-8">
+                    <h3 class="text-3xl font-bold text-[#4682B4] text-center">A Menu of Modern Frameworks</h3>
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                        <div class="bg-white rounded-lg shadow-md p-6">
+                            <h4 class="text-xl font-bold text-[#5F9EA0] mb-2">GTD (Getting Things Done)</h4>
+                            <p>A classic system for capturing, clarifying, organizing, reflecting, and engaging with tasks. Best for those who feel overwhelmed and need a structured way to externalize their commitments.</p>
+                        </div>
+                        <div class="bg-white rounded-lg shadow-md p-6">
+                            <h4 class="text-xl font-bold text-[#5F9EA0] mb-2">PARA Method</h4>
+                            <p>An organizational system for digital information based on actionability: Projects, Areas, Resources, and Archives. Best for knowledge workers managing large amounts of digital content.</p>
+                        </div>
+                        <div class="bg-white rounded-lg shadow-md p-6">
+                            <h4 class="text-xl font-bold text-[#5F9EA0] mb-2">Timeboxing</h4>
+                            <p>Allocating a fixed time period to a planned activity. Best for procrastinators and those who need to focus deeply on specific tasks by creating clear constraints.</p>
+                        </div>
+                        <div class="bg-white rounded-lg shadow-md p-6">
+                            <h4 class="text-xl font-bold text-[#5F9EA0] mb-2">MTR (Move/Think/Rest)</h4>
+                            <p>A daily structure prioritizing physical activity, focused cognitive work, and deliberate rest. Best for individuals seeking to balance physical and mental energy for sustainable performance.</p>
+                        </div>
+                        <div class="bg-white rounded-lg shadow-md p-6">
+                            <h4 class="text-xl font-bold text-[#5F9EA0] mb-2">EASE Framework</h4>
+                            <p>Prioritizes tasks based on Enjoyment, Expertise, and Effect. Best for creatives and entrepreneurs aiming to align their work with their passions and strengths for maximum impact.</p>
+                        </div>
+                        <div class="bg-white rounded-lg shadow-md p-6">
+                            <h4 class="text-xl font-bold text-[#5F9EA0] mb-2">Biological Prime Time</h4>
+                            <p>Scheduling your most important tasks during your natural peak energy windows. Best for anyone looking to maximize focus and output by working with their body's chronotype, not against it.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="rhythm" class="bg-white rounded-lg shadow-md p-6 md:p-8">
+                    <h3 class="text-3xl font-bold text-[#4682B4] mb-8 text-center">The Rhythm of Routine: A Cadence for Life</h3>
+                    <p class="text-center max-w-3xl mx-auto mb-8">A holistic system relies on a consistent cadence of planning and reflection. Integrating routines across different time horizons creates a reliable structure that supports long-term goals while managing short-term realities.</p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                        <div class="bg-white rounded-lg shadow-md p-6 border-t-4 border-[#5F9EA0]">
+                            <h4 class="text-xl font-bold mb-3">Daily</h4>
+                            <ul class="list-disc list-inside space-y-2 text-sm">
+                                <li><strong>2-Minute Rule:</strong> If it takes less than 2 minutes, do it now.</li>
+                                <li><strong>Prime Time Block:</strong> Schedule 1-2 hours of deep work during your peak energy.</li>
+                                <li><strong>Daily Highlight:</strong> Define the one thing you want to accomplish.</li>
+                                <li><strong>Evening Shutdown:</strong> Clear inboxes and plan the next day.</li>
+                            </ul>
+                        </div>
+                        <div class="bg-white rounded-lg shadow-md p-6 border-t-4 border-[#5F9EA0]">
+                            <h4 class="text-xl font-bold mb-3">Weekly</h4>
+                            <ul class="list-disc list-inside space-y-2 text-sm">
+                                <li><strong>Weekly Review:</strong> Reflect on progress, clear inboxes, and plan the week ahead.</li>
+                                <li><strong>Goal Check-in:</strong> Review progress on current project and area goals.</li>
+                                <li><strong>Social &amp; Rest Planning:</strong> Intentionally schedule time for relationships and recovery.</li>
+                                <li><strong>Financial Check-in:</strong> Review weekly spending and budget.</li>
+                            </ul>
+                        </div>
+                        <div class="bg-white rounded-lg shadow-md p-6 border-t-4 border-[#5F9EA0]">
+                            <h4 class="text-xl font-bold mb-3">Monthly</h4>
+                            <ul class="list-disc list-inside space-y-2 text-sm">
+                                <li><strong>Goal Review:</strong> Assess progress on larger goals and set priorities for the next month.</li>
+                                <li><strong>Budget Review:</strong> Analyze monthly income, expenses, and savings.</li>
+                                <li><strong>Area Maintenance:</strong> Check in on key life areas (health, relationships, home).</li>
+                                <li><strong>Digital Cleanup:</strong> Archive completed projects and clear desktop/downloads.</li>
+                            </ul>
+                        </div>
+                        <div class="bg-white rounded-lg shadow-md p-6 border-t-4 border-[#5F9EA0]">
+                            <h4 class="text-xl font-bold mb-3">Quarterly</h4>
+                            <ul class="list-disc list-inside space-y-2 text-sm">
+                                <li><strong>Life Vision Review:</strong> Reconnect with long-term vision and values.</li>
+                                <li><strong>Set New Goals:</strong> Define 1-3 major outcomes for the next 90 days.</li>
+                                <li><strong>Deep Rest:</strong> Plan for a longer break or vacation.</li>
+                                <li><strong>Systems Audit:</strong> Review and refine productivity tools and workflows.</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="holistic-app" class="bg-white rounded-lg shadow-md p-6 md:p-8">
+                    <h3 class="text-3xl font-bold text-[#4682B4] mb-4 text-center">Holistic Application: Balancing Life's Domains</h3>
+                    <p class="text-center max-w-3xl mx-auto mb-8">An effective system doesn't just manage work; it integrates and balances all key areas of life. A siloed approach often leads to over-investment in one area (like work) at the expense of others, while a holistic system fosters intentional growth across the board.</p>
+                    <div class="chart-container">
+                        <canvas id="lifeBalanceRadarChart"></canvas>
+                    </div>
+                    <p class="text-center text-sm text-gray-600 mt-4">This radar chart visualizes the shift from a work-centric, unbalanced life to a more harmonious state achieved through a holistic system. The goal is not perfect symmetry but intentional allocation of energy across all important domains.</p>
+                </section>
+
+                <section id="build-system" class="bg-white rounded-lg shadow-md p-6 md:p-8">
+                    <h3 class="text-3xl font-bold text-[#4682B4] mb-8 text-center">Building Your Personal Life OS: A Simple Path</h3>
+                    <div class="flex flex-col md:flex-row items-stretch justify-center gap-4">
+                        <div class="flowchart-node">
+                            <h4 class="font-bold text-lg">1. Capture</h4>
+                            <p>Use a single, trusted system (like a notebook or app) to capture everything that has your attention.</p>
+                        </div>
+                        <div class="flowchart-connector"></div>
+                        <div class="flowchart-node">
+                            <h4 class="font-bold text-lg">2. Organize</h4>
+                            <p>Sort captured items using PARA (Projects, Areas, Resources, Archives) to keep things actionable.</p>
+                        </div>
+                        <div class="flowchart-connector"></div>
+                        <div class="flowchart-node">
+                            <h4 class="font-bold text-lg">3. Plan</h4>
+                            <p>Use Timeboxing and Biological Prime Time to schedule your most important tasks for the week.</p>
+                        </div>
+                        <div class="flowchart-connector"></div>
+                        <div class="flowchart-node">
+                            <h4 class="font-bold text-lg">4. Review</h4>
+                            <p>Engage in weekly and monthly reviews to adjust plans, track progress, and stay aligned with your goals.</p>
+                        </div>
+                    </div>
+                </section>
+            </section>
+
+            <section id="fulcrum" class="space-y-8">
+                <div class="text-center max-w-3xl mx-auto">
+                    <h2 class="text-3xl font-bold accent-text mb-4">Fulcrum — The Companion App Concept</h2>
+                    <p class="text-lg text-gray-600">Fulcrum is a hypothetical platform designed to enforce the rhythms above. Think of it as scaffolding that holds your Life OS upright while you do the living.</p>
+                </div>
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                    <div class="feature-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">1. Capture Hub</h3>
+                        <p class="text-gray-600">A universal inbox funnels tasks, notes, voice memos, and links into one queue. Guided prompts ask whether an item is actionable, clarify next steps, and encourage immediate two-minute completions.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">2. Organization Layer</h3>
+                        <p class="text-gray-600">PARA is built into the workspace. Projects carry goals and deadlines, Areas maintain standards, Resources house research, and the Archive keeps history accessible.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">3. Planning &amp; Execution Engine</h3>
+                        <p class="text-gray-600">Drag-and-drop timeboxing integrates with your calendar. Track energy to surface Biological Prime Time recommendations, schedule Move/Think/Rest blocks, and launch focus mode when a session begins.</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">4. Reflection Module</h3>
+                        <p class="text-gray-600">Weekly reviews become wizard-driven walkthroughs, monthly Lifescans visualize balance, and daily shutdown checklists ensure clean handoffs to tomorrow.</p>
+                    </div>
+                    <div class="feature-card lg:col-span-2">
+                        <h3 class="text-2xl font-semibold text-[#5F9EA0] mb-3">5. Holistic Dashboard</h3>
+                        <p class="text-gray-600">A command center reveals today’s timeboxes, highlights top priorities, tracks time invested across life domains, and connects projects to long-range goals so daily actions always ladder up.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section id="closing" class="prose max-w-none">
+                <h2 class="text-3xl font-bold accent-text mb-4">Start Small, Iterate Forever</h2>
+                <p>Architecting a Life OS is an act of continuous prototyping. Pick one capture habit, one review ritual, and one energy experiment to run this week. Notice what sticks, discard what doesn’t, and keep tuning the system to match the season you’re in. The point isn’t perfection—it’s clarity, resilience, and momentum.</p>
+                <p>When you trust your system, you get to redirect energy away from anxiety and toward building the life you actually want. That’s the real win: not a prettier to-do list, but a balanced operating system that makes meaningful progress inevitable.</p>
+            </section>
+        </article>
+    </main>
+
+    <footer class="text-center py-8 px-4 mt-8 bg-[#B0C4DE] text-[#4682B4]">
+        <p class="text-sm">Infographic sections created to visualize a balanced and sustainable approach to modern productivity.</p>
+    </footer>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const wrapLabel = (label) => {
+                if (label.length > 16) {
+                    const words = label.split(' ');
+                    const lines = [];
+                    let currentLine = '';
+                    words.forEach(word => {
+                        if ((currentLine + ' ' + word).trim().length > 16) {
+                            lines.push(currentLine.trim());
+                            currentLine = word;
+                        } else {
+                            currentLine = (currentLine + ' ' + word).trim();
+                        }
+                    });
+                    lines.push(currentLine.trim());
+                    return lines;
+                }
+                return label;
+            };
+
+            const tooltipTitleCallback = (tooltipItems) => {
+                const item = tooltipItems[0];
+                let label = item.chart.data.labels[item.dataIndex];
+                if (Array.isArray(label)) {
+                    return label.join(' ');
+                } else {
+                    return label;
+                }
+            };
+
+            const sharedChartOptions = {
+                maintainAspectRatio: false,
+                responsive: true,
+                plugins: {
+                    legend: {
+                        labels: {
+                            color: '#4682B4',
+                            font: {
+                                size: 14
+                            }
+                        }
+                    },
+                    tooltip: {
+                        callbacks: {
+                           title: tooltipTitleCallback
+                        }
+                    }
+                },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        grid: {
+                            color: '#E0E0E0'
+                        },
+                        ticks: {
+                            color: '#5F9EA0'
+                        }
+                    },
+                    x: {
+                        grid: {
+                            display: false
+                        },
+                        ticks: {
+                            color: '#5F9EA0'
+                        }
+                    }
+                }
+            };
+
+            const frameworksCanvas = document.getElementById('frameworksComparisonChart');
+            if (frameworksCanvas) {
+                const frameworksCtx = frameworksCanvas.getContext('2d');
+                new Chart(frameworksCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: ['Flexibility', 'Energy Focus', 'Holistic Scope', 'Implementation Ease'],
+                        datasets: [
+                            {
+                                label: 'Traditional Systems',
+                                data: [4, 3, 5, 6],
+                                backgroundColor: '#ADD8E6',
+                                borderColor: '#ADD8E6',
+                                borderWidth: 1
+                            },
+                            {
+                                label: 'Newer Systems',
+                                data: [9, 8, 8, 7],
+                                backgroundColor: '#5F9EA0',
+                                borderColor: '#5F9EA0',
+                                borderWidth: 1
+                            }
+                        ]
+                    },
+                    options: sharedChartOptions
+                });
+            }
+
+            const lifeBalanceCanvas = document.getElementById('lifeBalanceRadarChart');
+            if (lifeBalanceCanvas) {
+                const lifeBalanceCtx = lifeBalanceCanvas.getContext('2d');
+                new Chart(lifeBalanceCtx, {
+                    type: 'radar',
+                    data: {
+                        labels: ['Work', wrapLabel('Personal Growth'), 'Finances', 'Relationships', wrapLabel('Social Life')],
+                        datasets: [{
+                            label: 'Before (Siloed Approach)',
+                            data: [9, 4, 5, 4, 3],
+                            fill: true,
+                            backgroundColor: 'rgba(173, 216, 230, 0.4)',
+                            borderColor: 'rgb(173, 216, 230)',
+                            pointBackgroundColor: 'rgb(173, 216, 230)',
+                            pointBorderColor: '#fff',
+                            pointHoverBackgroundColor: '#fff',
+                            pointHoverBorderColor: 'rgb(173, 216, 230)'
+                        }, {
+                            label: 'After (Holistic System)',
+                            data: [7, 8, 7, 8, 6],
+                            fill: true,
+                            backgroundColor: 'rgba(95, 158, 160, 0.4)',
+                            borderColor: 'rgb(95, 158, 160)',
+                            pointBackgroundColor: 'rgb(95, 158, 160)',
+                            pointBorderColor: '#fff',
+                            pointHoverBackgroundColor: '#fff',
+                            pointHoverBorderColor: 'rgb(95, 158, 160)'
+                        }]
+                    },
+                    options: {
+                        maintainAspectRatio: false,
+                        responsive: true,
+                        plugins: {
+                             legend: {
+                                labels: {
+                                    color: '#4682B4'
+                                }
+                            },
+                             tooltip: {
+                                callbacks: {
+                                    title: tooltipTitleCallback
+                                }
+                            }
+                        },
+                        scales: {
+                            r: {
+                                angleLines: {
+                                    color: '#E0E0E0'
+                                },
+                                grid: {
+                                    color: '#E0E0E0'
+                                },
+                                pointLabels: {
+                                    font: {
+                                        size: 14
+                                    },
+                                    color: '#4682B4'
+                                },
+                                ticks: {
+                                    backdropColor: '#F0F8FF',
+                                    color: '#5F9EA0'
+                                },
+                                suggestedMin: 0,
+                                suggestedMax: 10
+                            }
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+</body>
+</html>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -182,6 +182,24 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">LifeOS Strategy</span>
+                            <span class="text-xs text-gray-500">Oct 6, 2025</span>
+                        </div>
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="beyond-the-to-do-list-life-operating-system.html" class="hover:text-indigo-400 transition-colors">
+                                Beyond the To-Do List: Architecting a Life Operating System That Actually Works
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            Blend GTD, PARA, and energy-aware timeboxing into a resilient Life OS, then reinforce it with rituals and a companion app concept named Fulcrum.
+                        </p>
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-500">📚 9 min read</span>
+                            <a href="beyond-the-to-do-list-life-operating-system.html" class="text-indigo-400 hover:underline">Read →</a>
+                        </div>
+                    </article>
+                    <article class="blog-card p-6 rounded-xl">
+                        <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Learning Systems</span>
                             <span class="text-xs text-gray-500">Sep 24, 2025</span>
                         </div>


### PR DESCRIPTION
## Summary
- add the "Beyond the To-Do List" Life OS architecture blog with integrated visuals and Fulcrum app concept
- embed the provided infographic-style sections with Tailwind and Chart.js for comparative and balance views
- feature the new post on the blogs index so it surfaces alongside other recent articles

## Testing
- not run (static HTML content)


------
https://chatgpt.com/codex/tasks/task_e_68d03c525104832587b278996e191c72