### PR TITLE
Add habit-focused apartment cleaning blog

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -182,6 +182,24 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Habit Design</span>
+                            <span class="text-xs text-gray-500">Oct 10, 2025</span>
+                        </div>
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="the-struggle-of-keeping-my-apartment-clean.html" class="hover:text-indigo-400 transition-colors">
+                                The Struggle of Keeping My Apartment Clean (and How I’m Fighting Back)
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            Reclaim your mornings by pairing atomic habits with zone-based resets, accountability loops, and a 30-day plan that keeps clutter from stealing your time.
+                        </p>
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-500">📚 8 min read</span>
+                            <a href="the-struggle-of-keeping-my-apartment-clean.html" class="text-indigo-400 hover:underline">Read →</a>
+                        </div>
+                    </article>
+                    <article class="blog-card p-6 rounded-xl">
+                        <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">LifeOS Strategy</span>
                             <span class="text-xs text-gray-500">Oct 6, 2025</span>
                         </div>

--- a/blogs/the-struggle-of-keeping-my-apartment-clean.html
+++ b/blogs/the-struggle-of-keeping-my-apartment-clean.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>The Struggle of Keeping My Apartment Clean (and How I’m Fighting Back) | ChrisCruz.ai</title>
+    <meta name="description" content="A candid look at the friction of everyday clutter, the systems that failed, and the new atomic habits and rituals I’m building to keep my apartment—and time—under control." />
+    <meta name="keywords" content="home organization, cleaning habits, atomic habits, productivity, personal systems" />
+    <meta name="author" content="Christopher Manuel Cruz-Guzman" />
+    <meta property="og:title" content="The Struggle of Keeping My Apartment Clean (and How I’m Fighting Back)" />
+    <meta property="og:description" content="Turning daily cleaning friction into a livable system with atomic habits, micro-routines, and a 30-day reclaim plan." />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://chriscruz.ai/blogs/the-struggle-of-keeping-my-apartment-clean.html" />
+    <meta property="og:image" content="https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1400&q=80" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="The Struggle of Keeping My Apartment Clean (and How I’m Fighting Back)" />
+    <meta name="twitter:description" content="Daily clutter was stealing my time. Here’s the system I’m building to stop tripping over yesterday’s mess." />
+    <meta name="twitter:image" content="https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1400&q=80" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            color-scheme: only light;
+        }
+        body {
+            font-family: 'Inter', sans-serif;
+            background: linear-gradient(180deg, #f9fbff 0%, #f1f5ff 100%);
+            color: #1f2937;
+        }
+        .glass-card {
+            background: rgba(255, 255, 255, 0.88);
+            border: 1px solid rgba(99, 102, 241, 0.12);
+            box-shadow: 0 24px 45px rgba(15, 23, 42, 0.08);
+            border-radius: 1.25rem;
+        }
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding: 0.35rem 0.85rem;
+            border-radius: 999px;
+            background: rgba(59, 130, 246, 0.12);
+            color: #1d4ed8;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .section-title {
+            font-size: clamp(1.75rem, 2.2vw, 2.5rem);
+            font-weight: 700;
+            color: #1e3a8a;
+        }
+        .subtitle {
+            color: #475569;
+        }
+        .toc-card {
+            background: rgba(255, 255, 255, 0.92);
+            border-radius: 1rem;
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            box-shadow: 0 18px 38px rgba(30, 64, 175, 0.08);
+        }
+        .toc-card a {
+            color: #1d4ed8;
+        }
+        .callout-success {
+            background: linear-gradient(135deg, rgba(34, 197, 94, 0.12), rgba(134, 239, 172, 0.25));
+            border-left: 4px solid #22c55e;
+        }
+        .callout-warning {
+            background: linear-gradient(135deg, rgba(250, 204, 21, 0.12), rgba(254, 240, 138, 0.25));
+            border-left: 4px solid #facc15;
+        }
+        .callout-info {
+            background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(191, 219, 254, 0.25));
+            border-left: 4px solid #3b82f6;
+        }
+        .habit-grid {
+            display: grid;
+            gap: 1.5rem;
+        }
+        @media (min-width: 768px) {
+            .habit-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+        }
+        .habit-card {
+            background: rgba(255, 255, 255, 0.95);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            border-radius: 1rem;
+            padding: 1.5rem;
+            box-shadow: 0 16px 30px rgba(15, 23, 42, 0.06);
+        }
+        .plan-grid {
+            display: grid;
+            gap: 1.25rem;
+        }
+        @media (min-width: 1024px) {
+            .plan-grid {
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+            }
+        }
+        .plan-step {
+            background: rgba(255, 255, 255, 0.9);
+            border: 1px solid rgba(99, 102, 241, 0.16);
+            border-radius: 1rem;
+            padding: 1.4rem;
+            position: relative;
+            overflow: hidden;
+        }
+        .plan-step::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border-radius: 1rem;
+            border: 1px dashed rgba(99, 102, 241, 0.35);
+            pointer-events: none;
+        }
+        .plan-badge {
+            display: inline-flex;
+            justify-content: center;
+            align-items: center;
+            width: 2rem;
+            height: 2rem;
+            border-radius: 999px;
+            background: rgba(59, 130, 246, 0.12);
+            color: #1d4ed8;
+            font-weight: 600;
+            margin-bottom: 1rem;
+        }
+    </style>
+</head>
+<body class="antialiased">
+    <header class="bg-gradient-to-br from-sky-200 via-sky-100 to-white py-20 md:py-28 px-6">
+        <div class="max-w-4xl mx-auto text-center space-y-6">
+            <div class="flex justify-center">
+                <span class="pill">Habit Design</span>
+            </div>
+            <h1 class="text-4xl md:text-5xl font-extrabold text-slate-900 leading-tight">
+                The Struggle of Keeping My Apartment Clean (and How I’m Fighting Back)
+            </h1>
+            <p class="text-lg md:text-xl text-slate-600 max-w-2xl mx-auto">
+                Every exit from my apartment used to feel like wading through molasses—piles of laundry, wandering gadgets, and delayed departures. This is the story of why that friction kept winning and the systems I’m building to reclaim my mornings.
+            </p>
+            <div class="text-sm text-slate-500">
+                <span>Published October 10, 2025 · 8 minute read</span>
+            </div>
+        </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-6 md:px-10 -mt-12 pb-24">
+        <article class="glass-card p-8 md:p-12 space-y-16">
+            <section class="toc-card p-6 md:p-8 space-y-4">
+                <h2 class="text-2xl font-semibold text-slate-800">Table of Contents</h2>
+                <nav class="space-y-3 text-sm md:text-base">
+                    <a href="#friction" class="block hover:text-indigo-600">1. The hidden tax of tiny messes</a>
+                    <a href="#strategies" class="block hover:text-indigo-600">2. What I tried (and why it didn’t stick)</a>
+                    <a href="#habits" class="block hover:text-indigo-600">3. Rebuilding with atomic habits</a>
+                    <a href="#systems" class="block hover:text-indigo-600">4. Systems that keep me honest</a>
+                    <a href="#plan" class="block hover:text-indigo-600">5. The 30-day reclaim plan</a>
+                    <a href="#resources" class="block hover:text-indigo-600">6. Resources &amp; conversation starters</a>
+                </nav>
+            </section>
+
+            <section id="friction" class="space-y-6">
+                <h2 class="section-title">The hidden tax of tiny messes</h2>
+                <p class="subtitle text-lg">It’s rarely a catastrophic mess. It’s a chorus of micro-delays that steal compound minutes from every departure.</p>
+                <div class="callout-warning p-6 rounded-xl space-y-4">
+                    <h3 class="text-xl font-semibold text-amber-700">The friction loop</h3>
+                    <ul class="list-disc list-inside text-slate-700 space-y-2">
+                        <li>Clean clothes without a “home” sit on a chair, begging to be sorted.</li>
+                        <li>Dishes dry on the counter because the cabinets were never reset.</li>
+                        <li>Chargers, notebooks, or travel gear rest wherever I last used them, forcing a scavenger hunt when it’s time to leave.</li>
+                    </ul>
+                    <p class="text-slate-700">The real cost isn’t the mess; it’s the attention switch. Every unshelved item becomes a last-minute decision, and the mental tab stays open long after I’ve left.</p>
+                </div>
+                <p>I used to reserve “cleaning” for heroic weekend resets. But clutter accumulates on weekdays, not weekends. The friction is cumulative: the more energy I expend navigating around stuff, the less I have for deep work, relationships, or recovery.</p>
+            </section>
+
+            <section id="strategies" class="space-y-8">
+                <h2 class="section-title">What I tried (and why it didn’t stick)</h2>
+                <p class="subtitle">The experiments helped, but each failed for a different reason. Documenting them turned the mess into data.</p>
+                <div class="habit-grid">
+                    <div class="habit-card space-y-4">
+                        <h3 class="text-xl font-semibold text-slate-800">Finding a home for everything</h3>
+                        <p>When every item had a landing zone, the apartment felt easier to navigate. But I never treated “put it back” as a non-negotiable ritual. Without a trigger, the system decayed.</p>
+                        <div class="callout-info p-4 rounded-lg space-y-2">
+                            <p class="text-sm text-slate-700"><strong>Lesson:</strong> A storage decision isn’t a habit. Habits require cues, repetition, and reinforcement.</p>
+                        </div>
+                    </div>
+                    <div class="habit-card space-y-4">
+                        <h3 class="text-xl font-semibold text-slate-800">Decluttering &amp; storage blitzes</h3>
+                        <p>Purging closets, boxing seasonal gear, and donating duplicates delivered a dopamine rush. Yet “miscellaneous bins” multiplied, and without labeled zones, I recreated the same chaos—just inside prettier containers.</p>
+                        <div class="callout-info p-4 rounded-lg space-y-2">
+                            <p class="text-sm text-slate-700"><strong>Lesson:</strong> Decluttering is a project. Maintenance is an identity.</p>
+                        </div>
+                    </div>
+                    <div class="habit-card space-y-4">
+                        <h3 class="text-xl font-semibold text-slate-800">Building a cleaning checklist app</h3>
+                        <p>I even coded my own checklist app with daily/weekly/monthly views. It felt like accountability—until I stopped opening it. Without rituals baked into my day, the app became another piece of clutter.</p>
+                        <div class="callout-info p-4 rounded-lg space-y-2">
+                            <p class="text-sm text-slate-700"><strong>Lesson:</strong> Tools amplify existing habits. They rarely invent them.</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section id="habits" class="space-y-8">
+                <h2 class="section-title">Rebuilding with atomic habits</h2>
+                <p class="subtitle">The fight isn’t about motivation. It’s about designing triggers, rewards, and micro-commitments that survive real life.</p>
+                <div class="callout-success p-6 rounded-xl space-y-4">
+                    <h3 class="text-xl font-semibold text-emerald-700">My atomic habit stack</h3>
+                    <ul class="list-disc list-inside text-slate-700 space-y-2">
+                        <li><strong>Anchor:</strong> Pair every transition—leaving a room, ending work, finishing laundry—with a 60-second tidy loop.</li>
+                        <li><strong>Reward:</strong> Queue a favorite playlist or podcast episode that only plays during cleanup sessions.</li>
+                        <li><strong>Tracking:</strong> Use a physical scoreboard on the fridge with seven slots. Stickers > notifications.</li>
+                        <li><strong>Identity:</strong> Adopt the mantra “I reset spaces before I exit them.” Say it aloud until it feels true.</li>
+                    </ul>
+                </div>
+                <p>Atomic habits thrive when they’re stupidly small. Instead of declaring “keep the apartment clean,” I commit to finishing each micro-task completely—laundry that’s folded <em>and</em> put away, dishes that are washed <em>and</em> stored.</p>
+            </section>
+
+            <section id="systems" class="space-y-8">
+                <h2 class="section-title">Systems that keep me honest</h2>
+                <p class="subtitle">If habits are the rhythm, systems are the sheet music. These guardrails protect future me from morning chaos.</p>
+                <div class="space-y-6">
+                    <div class="glass-card border border-indigo-100 p-6 md:p-8 space-y-4">
+                        <h3 class="text-xl font-semibold text-slate-900">1. Zoning the apartment</h3>
+                        <p class="text-slate-700">I mapped every object to one of five zones: Entry, Kitchen, Lounge, Workspace, Reset (utility/storage). Each zone now has a quick checklist pinned nearby. No more ambiguous “put it somewhere” decisions.</p>
+                    </div>
+                    <div class="glass-card border border-indigo-100 p-6 md:p-8 space-y-4">
+                        <h3 class="text-xl font-semibold text-slate-900">2. Real-time resets</h3>
+                        <p class="text-slate-700">Before switching tasks, I run a 3-item sweep: surfaces cleared, floor path cleared, next action staged. It converts liminal moments into maintenance without scheduling extra time.</p>
+                    </div>
+                    <div class="glass-card border border-indigo-100 p-6 md:p-8 space-y-4">
+                        <h3 class="text-xl font-semibold text-slate-900">3. Accountability loop</h3>
+                        <p class="text-slate-700">Sunday evenings now include a photo check-in shared with a friend who is also battling clutter. We rate each other’s resets (Green, Yellow, Red) and share one improvement for the upcoming week.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section id="plan" class="space-y-8">
+                <h2 class="section-title">The 30-day reclaim plan</h2>
+                <p class="subtitle">Four weekly sprints turn the vision into a trackable experiment. Each week builds on the last.</p>
+                <div class="plan-grid">
+                    <div class="plan-step space-y-3">
+                        <span class="plan-badge">1</span>
+                        <h3 class="text-lg font-semibold text-slate-900">Week 1 · Audit &amp; baseline</h3>
+                        <ul class="list-disc list-inside text-sm text-slate-700 space-y-2">
+                            <li>Log every friction point for seven days.</li>
+                            <li>Label storage zones with painter’s tape.</li>
+                            <li>Photograph morning departure setup before bed.</li>
+                        </ul>
+                    </div>
+                    <div class="plan-step space-y-3">
+                        <span class="plan-badge">2</span>
+                        <h3 class="text-lg font-semibold text-slate-900">Week 2 · Habit anchors</h3>
+                        <ul class="list-disc list-inside text-sm text-slate-700 space-y-2">
+                            <li>Attach tidy loops to meals, work sessions, and workouts.</li>
+                            <li>Start the playlist-only-during-cleanup rule.</li>
+                            <li>Track streaks on the fridge scoreboard.</li>
+                        </ul>
+                    </div>
+                    <div class="plan-step space-y-3">
+                        <span class="plan-badge">3</span>
+                        <h3 class="text-lg font-semibold text-slate-900">Week 3 · Optimize zones</h3>
+                        <ul class="list-disc list-inside text-sm text-slate-700 space-y-2">
+                            <li>Upgrade storage tools only where friction remains.</li>
+                            <li>Create a “launchpad” tray for keys, wallet, headphones.</li>
+                            <li>Run two-minute sweeps before leaving any zone.</li>
+                        </ul>
+                    </div>
+                    <div class="plan-step space-y-3">
+                        <span class="plan-badge">4</span>
+                        <h3 class="text-lg font-semibold text-slate-900">Week 4 · Stress test &amp; iterate</h3>
+                        <ul class="list-disc list-inside text-sm text-slate-700 space-y-2">
+                            <li>Host someone for dinner or coffee to test readiness.</li>
+                            <li>Review photos + streak data; adjust triggers.</li>
+                            <li>Document the maintenance checklist for future months.</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <section id="resources" class="space-y-8">
+                <h2 class="section-title">Resources &amp; conversation starters</h2>
+                <div class="grid gap-6 md:grid-cols-2">
+                    <div class="habit-card space-y-3">
+                        <h3 class="text-lg font-semibold text-slate-900">Playlists &amp; prompts</h3>
+                        <ul class="list-disc list-inside text-sm text-slate-700 space-y-2">
+                            <li><strong>Focus Flow:</strong> 20-minute upbeat mix reserved only for cleaning loops.</li>
+                            <li><strong>Podcast pairing:</strong> Habit-focused episodes queued to autoplayer as a reward.</li>
+                            <li><strong>Reflection prompt:</strong> “Where did friction slow me down today and how can I pre-decide tomorrow’s reset?”</li>
+                        </ul>
+                    </div>
+                    <div class="habit-card space-y-3">
+                        <h3 class="text-lg font-semibold text-slate-900">Metrics that matter</h3>
+                        <ul class="list-disc list-inside text-sm text-slate-700 space-y-2">
+                            <li>Departure lag in minutes (goal: &lt; 3).</li>
+                            <li>Days with full-zone resets completed (goal: 5/7).</li>
+                            <li>Weekly photo check-ins rated Green (goal: 3 consecutive weeks).</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="callout-info p-6 rounded-xl space-y-4">
+                    <h3 class="text-xl font-semibold text-indigo-700">Let’s trade strategies</h3>
+                    <p class="text-slate-700">I know I’m not the only one who loses time to rogue laundry baskets and kitchen counter creep. What routines, tools, or mindset shifts have helped you keep your space reset-ready? Drop me a note—your experiment might be the missing piece of my system.</p>
+                </div>
+            </section>
+        </article>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -392,6 +392,17 @@
             <div class="writing-grid">
                 <article class="writing-card">
                     <div class="writing-meta">
+                        <span class="writing-category">Habit Design</span>
+                        <span class="writing-date">October 10, 2025</span>
+                    </div>
+                    <h3 class="writing-title">The Struggle of Keeping My Apartment Clean (and How I’m Fighting Back)</h3>
+                    <p class="writing-excerpt">
+                        How I’m turning daily clutter friction into atomic habits, zone checklists, and a 30-day reclaim plan so leaving home no longer feels like an obstacle course.
+                    </p>
+                    <a href="blogs/the-struggle-of-keeping-my-apartment-clean.html" class="writing-link">Build the Reset Ritual →</a>
+                </article>
+                <article class="writing-card">
+                    <div class="writing-meta">
                         <span class="writing-category">Learning Systems</span>
                         <span class="writing-date">September 24, 2025</span>
                     </div>


### PR DESCRIPTION
## Summary
- add a new habit design blog post about taming apartment clutter with atomic habits and a 30-day reclaim plan
- feature the post on the home page writing grid and the blogs landing page latest posts section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0552128008325b8c8f0fc76043603