### PR TITLE
Add dedicated changelog page and navigation link

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -1,0 +1,1118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cruz AI Project Change Log</title>
+    <meta name="description" content="All notable updates to the Chris Cruz AI repository, listed by date with direct links to the affected files.">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/main.css">
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-container">
+            <div class="nav-logo">
+                <a href="/">CC</a>
+            </div>
+            <div class="nav-menu">
+                <a href="/#about" class="nav-link">About</a>
+                <a href="/#work" class="nav-link">Work</a>
+                <a href="/#projects" class="nav-link">Projects</a>
+                <a href="/#writing" class="nav-link">Writing</a>
+                <a href="changelog.html" class="nav-link active" aria-current="page">Change Log</a>
+                <a href="/#contact" class="nav-link">Contact</a>
+            </div>
+            <div class="nav-toggle">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+        </div>
+    </nav>
+
+    <main class="changelog-page">
+        <section class="changelog-hero">
+            <div class="container">
+                <div class="changelog-hero__content">
+                    <span class="changelog-hero__badge">Project Change Log</span>
+                    <h1 class="changelog-hero__title">All notable updates to the Chris Cruz AI site</h1>
+                    <p class="changelog-hero__subtitle">Every entry is sourced from the Git history and organized by the date it shipped so you can trace the evolution of the site at a glance.</p>
+                    <p class="changelog-hero__note">Following <a href="https://keepachangelog.com/en/1.1.0/" target="_blank" rel="noopener">Keep a Changelog</a> principles with commit-level references.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="changelog-content">
+            <div class="container">
+                <div class="changelog-guidelines">
+                    <h2>How to read this log</h2>
+                    <ul>
+                        <li>The most recent updates appear at the top. Older work scrolls downward.</li>
+                        <li>Each change lists the commit title, short hash, and every file it touched.</li>
+                        <li>Status badges highlight whether a file was added or updated in that commit.</li>
+                    </ul>
+                </div>
+                <div class="changelog-timeline">
+
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-09-21</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Launch comprehensive HTML change log experience</h3>
+        <p class="changelog-entry__meta">Published on 2025-09-21</p>
+      </header>
+      <p class="changelog-entry__description">Introduced a dedicated change log page, refreshed navigation to link to it, and added tailored styling for the new timeline layout.</p>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="changelog.html">changelog.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="styles/main.css">styles/main.css</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add habit-focused apartment cleaning blog</h3>
+        <p class="changelog-entry__meta">Commit <code>ce2779c</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/the-struggle-of-keeping-my-apartment-clean.html">blogs/the-struggle-of-keeping-my-apartment-clean.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add strategic narrative for Q4 transaction history plan</h3>
+        <p class="changelog-entry__meta">Commit <code>14453ef</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/q4-quarterly-planning-transaction-history.html">blogs/q4-quarterly-planning-transaction-history.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add Life OS architecture blog and update index</h3>
+        <p class="changelog-entry__meta">Commit <code>2078a84</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/beyond-the-to-do-list-life-operating-system.html">blogs/beyond-the-to-do-list-life-operating-system.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">docs: add personalized event notification blueprint readme</h3>
+        <p class="changelog-entry__meta">Commit <code>277c4fd</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/personalized-event-notification-engine/README.md">blogs/personalized-event-notification-engine/README.md</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add Life OS productivity system blog with light theme</h3>
+        <p class="changelog-entry__meta">Commit <code>7e64fc2</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/my-personal-life-os.html">blogs/my-personal-life-os.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Create unified Todoist project planning experience</h3>
+        <p class="changelog-entry__meta">Commit <code>6ed10c1</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/index.html">Apps/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/project-planner.html">Apps/project-planner.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/todoist-project-planning.html">Apps/todoist-project-planning.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/todoist-sorter.html">Apps/todoist-sorter.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">feat: refresh q4 planning blog with new artifacts</h3>
+        <p class="changelog-entry__meta">Commit <code>1918205</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/q4-quarterly-planning-transaction-history.html">blogs/q4-quarterly-planning-transaction-history.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add LLM text organization workflow blog</h3>
+        <p class="changelog-entry__meta">Commit <code>9634b99</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/organize-text-llm-agent-workflow.html">blogs/organize-text-llm-agent-workflow.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Expand Cuculi AI microservices blueprint with serverless architecture</h3>
+        <p class="changelog-entry__meta">Commit <code>7153d50</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/cuculi-notification-ai-microservices.html">blogs/cuculi-notification-ai-microservices.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add Cuculi notification microservices blog and update listings</h3>
+        <p class="changelog-entry__meta">Commit <code>81d7714</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/cuculi-notification-ai-microservices.html">blogs/cuculi-notification-ai-microservices.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Enable desktop drag-and-drop between quadrants</h3>
+        <p class="changelog-entry__meta">Commit <code>c92da87</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/project-planner.html">Apps/project-planner.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Open home page blog links in new tabs</h3>
+        <p class="changelog-entry__meta">Commit <code>cc8419b</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="js/main.js">js/main.js</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add Cuculi AI microservices demo app and blog blueprint</h3>
+        <p class="changelog-entry__meta">Commit <code>580fd0f</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/cuculi-ai-microservices-demo.html">Apps/cuculi-ai-microservices-demo.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/index.html">Apps/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/cuculi-ai-microservices-blueprint.html">blogs/cuculi-ai-microservices-blueprint.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-09-19</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Refocus smart nudges pillars and add supporting atomic notes</h3>
+        <p class="changelog-entry__meta">Commit <code>3bd3ed3</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/smart-nudges-implementation-deep-dive-cuculi-ai.html">blogs/smart-nudges-implementation-deep-dive-cuculi-ai.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="notes/index.html">notes/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="notes/smart-nudges-delivery-stack-note.html">notes/smart-nudges-delivery-stack-note.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="notes/smart-nudges-insight-control-note.html">notes/smart-nudges-insight-control-note.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="notes/smart-nudges-psychology-impact-note.html">notes/smart-nudges-psychology-impact-note.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="notes/smart-nudges-trigger-configuration-note.html">notes/smart-nudges-trigger-configuration-note.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add quotes and light theme styling to transaction history blog</h3>
+        <p class="changelog-entry__meta">Commit <code>f1a4177</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/strategic-transaction-history-architecture.html">blogs/strategic-transaction-history-architecture.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add Prompt DB app and update navigation</h3>
+        <p class="changelog-entry__meta">Commit <code>ed07409</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/index.html">Apps/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/prompt-db.html">Apps/prompt-db.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Refresh troubleshooting blog with light progressive layout</h3>
+        <p class="changelog-entry__meta">Commit <code>d215297</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/troubleshooting-transaction-enrichment-api.html">blogs/troubleshooting-transaction-enrichment-api.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Refine transaction history option narrative</h3>
+        <p class="changelog-entry__meta">Commit <code>ca4e83e</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/strategic-transaction-history-architecture.html">blogs/strategic-transaction-history-architecture.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Update home page work section to atomic notes</h3>
+        <p class="changelog-entry__meta">Commit <code>c73d7f3</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-09-18</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add corporate storytelling design blog and homepage link</h3>
+        <p class="changelog-entry__meta">Commit <code>c756f74</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/modern-corporate-storytelling-web-design.html">blogs/modern-corporate-storytelling-web-design.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add Cuculi AI smart nudges blog and link from homepage</h3>
+        <p class="changelog-entry__meta">Commit <code>f2c3f81</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/smart-nudges-implementation-deep-dive-cuculi-ai.html">blogs/smart-nudges-implementation-deep-dive-cuculi-ai.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add rendered preview modal to HTML viewer</h3>
+        <p class="changelog-entry__meta">Commit <code>3cc92bc</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/html-source-code-viewer.html">Apps/html-source-code-viewer.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Allow adding tasks without editing</h3>
+        <p class="changelog-entry__meta">Commit <code>06e6de4</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/project-planner.html">Apps/project-planner.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add completion filter controls to Todoist sorter</h3>
+        <p class="changelog-entry__meta">Commit <code>f13f4db</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/todoist-sorter.html">Apps/todoist-sorter.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Reframe CR enrichment update as status email</h3>
+        <p class="changelog-entry__meta">Commit <code>01beab6</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/troubleshooting-transaction-enrichment-api.html">blogs/troubleshooting-transaction-enrichment-api.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/versions/troubleshooting-transaction-enrichment-api-2025-09-19.html">blogs/versions/troubleshooting-transaction-enrichment-api-2025-09-19.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Refresh transaction history architecture blog content</h3>
+        <p class="changelog-entry__meta">Commit <code>9d35571</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/strategic-transaction-history-architecture.html">blogs/strategic-transaction-history-architecture.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add export actions to weight tracker history</h3>
+        <p class="changelog-entry__meta">Commit <code>789c53d</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/weight-tracker.html">Apps/weight-tracker.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add Q4 planning playbook blog and homepage link</h3>
+        <p class="changelog-entry__meta">Commit <code>655cf43</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/q4-quarterly-planning-transaction-history.html">blogs/q4-quarterly-planning-transaction-history.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add CR enrichment incident playbook blog and index links</h3>
+        <p class="changelog-entry__meta">Commit <code>eca2b80</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/troubleshooting-transaction-enrichment-api.html">blogs/troubleshooting-transaction-enrichment-api.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add transaction history architecture decision blog</h3>
+        <p class="changelog-entry__meta">Commit <code>b5cf23d</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/strategic-transaction-history-architecture.html">blogs/strategic-transaction-history-architecture.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add per-artifact URLs and history syncing</h3>
+        <p class="changelog-entry__meta">Commit <code>f4002e5</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/artifacts.html">Apps/artifacts.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add personal perspective to 5 forces infographic blog</h3>
+        <p class="changelog-entry__meta">Commit <code>3b0b784</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/infographic-the-5-forces-shaping-everything.html">blogs/infographic-the-5-forces-shaping-everything.html</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-09-16</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add five forces infographic blog and homepage link</h3>
+        <p class="changelog-entry__meta">Commit <code>4c954c7</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/infographic-the-5-forces-shaping-everything.html">blogs/infographic-the-5-forces-shaping-everything.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">List all blog posts on home page</h3>
+        <p class="changelog-entry__meta">Commit <code>08917c9</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add ETD testing strategy blog and update listings</h3>
+        <p class="changelog-entry__meta">Commit <code>8630f77</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/end-to-end-and-api-testing-for-etd.html">blogs/end-to-end-and-api-testing-for-etd.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add Cuculi backend slowdown diagnostic blog</h3>
+        <p class="changelog-entry__meta">Commit <code>a068591</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/cuculi-backend-slowdown-diagnostic.html">blogs/cuculi-backend-slowdown-diagnostic.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add ETD API blog post and link from homepage</h3>
+        <p class="changelog-entry__meta">Commit <code>783f073</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/etd-api-infographic-from-raw-data-to-rich-experience.html">blogs/etd-api-infographic-from-raw-data-to-rich-experience.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add DDA API migration blog and surface on site</h3>
+        <p class="changelog-entry__meta">Commit <code>7f46854</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/dda-api-migration-v2-to-v3.html">blogs/dda-api-migration-v2-to-v3.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-09-15</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add OfferUp and Otter.AI loops with dedicated checklists</h3>
+        <p class="changelog-entry__meta">Commit <code>03a68a0</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/building-va-in-the-loop-system.html">blogs/building-va-in-the-loop-system.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="offerup-loop-checklist.html">offerup-loop-checklist.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="otter-loop-checklist.html">otter-loop-checklist.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="publishing-engine-checklist.html">publishing-engine-checklist.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add AI-powered nudge engine blog and update links</h3>
+        <p class="changelog-entry__meta">Commit <code>7407baa</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/ai-powered-nudge-engine-for-social-dining.html">blogs/ai-powered-nudge-engine-for-social-dining.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Allow multi-line task content editing</h3>
+        <p class="changelog-entry__meta">Commit <code>0969795</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/todoist-sorter.html">Apps/todoist-sorter.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add debit card ETL demo app and blog</h3>
+        <p class="changelog-entry__meta">Commit <code>520b10b</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/debit-card-transaction-etl-demo.html">Apps/debit-card-transaction-etl-demo.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/index.html">Apps/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/debit-card-transaction-processing-demo.html">blogs/debit-card-transaction-processing-demo.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add VA-in-the-loop blog and update site links</h3>
+        <p class="changelog-entry__meta">Commit <code>c30bd14</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/building-va-in-the-loop-system.html">blogs/building-va-in-the-loop-system.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add HTML source viewer app and launch build log</h3>
+        <p class="changelog-entry__meta">Commit <code>82e85b9</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/html-source-code-viewer.html">Apps/html-source-code-viewer.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="Apps/index.html">Apps/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/html-source-viewer-build.html">blogs/html-source-viewer-build.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add DDA dashboard strategy blog and atomic note system</h3>
+        <p class="changelog-entry__meta">Commit <code>5820742</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/dda-going-primary-dashboard-strategy.html">blogs/dda-going-primary-dashboard-strategy.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="notes/data-consistency-dashboard-note.html">notes/data-consistency-dashboard-note.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="notes/event-store-reconciliation-dashboard-note.html">notes/event-store-reconciliation-dashboard-note.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="notes/index.html">notes/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="notes/latency-dashboard-note.html">notes/latency-dashboard-note.html</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-09-14</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">updated for the latest applications</h3>
+        <p class="changelog-entry__meta">Commit <code>2cb9298</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/data-vectorizer.html">Apps/data-vectorizer.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/fun-planner.html">Apps/fun-planner.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/index.html">Apps/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/manhattan-event-discovery.html">Apps/manhattan-event-discovery.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/ai-powered-virtual-assistant-management-framework-v2.html">blogs/ai-powered-virtual-assistant-management-framework-v2.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/ai-writing-revolution-productivity-guide.html">blogs/ai-writing-revolution-productivity-guide.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/reddit-startup-idea-validation-framer-wireframing.html">blogs/reddit-startup-idea-validation-framer-wireframing.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/smart-nudges-implementation-deep-dive.html">blogs/smart-nudges-implementation-deep-dive.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-08-30</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">updated files for maximum seo optimization</h3>
+        <p class="changelog-entry__meta">Commit <code>0d635dc</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="README.md">README.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/ai-productivity-enhancement.html">blogs/ai-productivity-enhancement.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/index.html">blogs/index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blogs/system-thinking-empire-building.html">blogs/system-thinking-empire-building.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="brand-hub.html">brand-hub.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="brand-story.html">brand-story.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="contact.html">contact.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="cruz-ai.html">cruz-ai.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="docs/CHRISTOPHER_CRUZ_GUZMAN.md">docs/CHRISTOPHER_CRUZ_GUZMAN.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="docs/LIFE_EXPERIENCES.md">docs/LIFE_EXPERIENCES.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="docs/PERSONAL_DOCUMENTATION_INDEX.md">docs/PERSONAL_DOCUMENTATION_INDEX.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="docs/PERSONAL_PHILOSOPHY.md">docs/PERSONAL_PHILOSOPHY.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="docs/PROFESSIONAL_JOURNEY.md">docs/PROFESSIONAL_JOURNEY.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="docs/VISION_AND_FUTURE.md">docs/VISION_AND_FUTURE.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="js/main.js">js/main.js</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="manifesto.html">manifesto.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="newsletter.html">newsletter.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="projects/lifeos.html">projects/lifeos.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="roadmap.html">roadmap.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="styles/cruz-ai.css">styles/cruz-ai.css</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="styles/main.css">styles/main.css</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="styles/project.css">styles/project.css</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="throne.html">throne.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">uploaded all apps and created lifeos</h3>
+        <p class="changelog-entry__meta">Commit <code>1ed7c33</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/artifacts.html">Apps/artifacts.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/bookmarks-manager.html">Apps/bookmarks-manager.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/food-diary.html">Apps/food-diary.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/friend-crm.html">Apps/friend-crm.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/goal-tracker.html">Apps/goal-tracker.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/hydration-tracker.html">Apps/hydration-tracker.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/inventory-management.html">Apps/inventory-management.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/knowledge-workflow.html">Apps/knowledge-workflow.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/marathon-training.html">Apps/marathon-training.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/pills-management.html">Apps/pills-management.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/project-planner.html">Apps/project-planner.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/routine-management.html">Apps/routine-management.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/second-brain.html">Apps/second-brain.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/sprint-tracker.html">Apps/sprint-tracker.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/stretch-tracker.html">Apps/stretch-tracker.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/todoist-sorter.html">Apps/todoist-sorter.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/upkeep.html">Apps/upkeep.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/weight-tracker.html">Apps/weight-tracker.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="Apps/workout-tracker.html">Apps/workout-tracker.html</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="docs/APP_ANALYSIS.md">docs/APP_ANALYSIS.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="docs/OVERVIEW.md">docs/OVERVIEW.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="docs/TECHNICAL_INTEGRATION.md">docs/TECHNICAL_INTEGRATION.md</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="lifeos.html">lifeos.html</a>
+        </li>
+      </ul>
+    </article>
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">test commit</h3>
+        <p class="changelog-entry__meta">Commit <code>d9e435f</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="README.md">README.md</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-08-29</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Add blog checklist for polishing and publishing drafts</h3>
+        <p class="changelog-entry__meta">Commit <code>876e31f</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="blog-checklist.html">blog-checklist.html</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-08-14</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Update index.html</h3>
+        <p class="changelog-entry__meta">Commit <code>65c90a3</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--updated">Updated</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-08-01</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Create CNAME</h3>
+        <p class="changelog-entry__meta">Commit <code>50258aa</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="CNAME">CNAME</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-07-28</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Create index.html</h3>
+        <p class="changelog-entry__meta">Commit <code>44dc64d</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="index.html">index.html</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+<section class="changelog-date">
+  <h2 class="changelog-date__title">2025-07-06</h2>
+  <div class="changelog-date__commits">
+    <article class="changelog-entry">
+      <header class="changelog-entry__header">
+        <h3 class="changelog-entry__title">Initial commit</h3>
+        <p class="changelog-entry__meta">Commit <code>069d5f1</code></p>
+      </header>
+      <ul class="changelog-entry__changes">
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href=".gitignore">.gitignore</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="LICENSE">LICENSE</a>
+        </li>
+        <li class="changelog-entry__change">
+          <span class="change-badge change-badge--added">Added</span> <a href="README.md">README.md</a>
+        </li>
+      </ul>
+    </article>
+  </div>
+</section>
+
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-brand">
+                    <div class="footer-logo">CC</div>
+                    <p class="footer-tagline">Building the future, one system at a time.</p>
+                </div>
+                <div class="footer-links">
+                    <div class="footer-section">
+                        <h4>Navigation</h4>
+                        <a href="/#about">About</a>
+                        <a href="/#work">Work</a>
+                        <a href="/#projects">Projects</a>
+                        <a href="/#writing">Writing</a>
+                        <a href="changelog.html">Change Log</a>
+                    </div>
+                    <div class="footer-section">
+                        <h4>Resources</h4>
+                        <a href="/lifeos">LifeOS</a>
+                        <a href="/cruz-ai">Cruz AI</a>
+                        <a href="/newsletter">Newsletter</a>
+                        <a href="/docs">Documentation</a>
+                    </div>
+                    <div class="footer-section">
+                        <h4>Connect</h4>
+                        <a href="https://twitter.com/chriscruzai" target="_blank" rel="noopener">Twitter</a>
+                        <a href="https://linkedin.com/in/christophercruzguzman" target="_blank" rel="noopener">LinkedIn</a>
+                        <a href="mailto:hello@chriscruz.ai">Email</a>
+                        <a href="/contact">Contact</a>
+                    </div>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 Christopher Manuel Cruz-Guzman. All rights reserved.</p>
+                <p>Built with ❤️ and lots of ☕</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
                 <a href="#work" class="nav-link">Work</a>
                 <a href="#projects" class="nav-link">Projects</a>
                 <a href="#writing" class="nav-link">Writing</a>
+                <a href="changelog.html" class="nav-link">Change Log</a>
                 <a href="#contact" class="nav-link">Contact</a>
             </div>
             <div class="nav-toggle">
@@ -727,6 +728,7 @@
                         <a href="#work">Work</a>
                         <a href="#projects">Projects</a>
                         <a href="#writing">Writing</a>
+                        <a href="changelog.html">Change Log</a>
                     </div>
                     <div class="footer-section">
                         <h4>Resources</h4>

--- a/styles/main.css
+++ b/styles/main.css
@@ -202,6 +202,12 @@ a:hover {
     color: var(--primary);
 }
 
+.nav-link.active,
+.nav-link[aria-current="page"] {
+    color: var(--primary);
+    font-weight: 600;
+}
+
 .nav-toggle {
     display: none;
     flex-direction: column;
@@ -893,6 +899,196 @@ a:hover {
     
     .card-icon {
         font-size: 1.5rem;
+    }
+}
+
+/* Change Log Page */
+.changelog-page {
+    padding-top: 120px;
+    background: var(--white);
+}
+
+.changelog-hero {
+    padding: var(--space-3xl) 0;
+    background: var(--gray-50);
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.changelog-hero__content {
+    max-width: 760px;
+}
+
+.changelog-hero__badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.12);
+    color: var(--primary);
+    margin-bottom: var(--space-sm);
+}
+
+.changelog-hero__title {
+    font-size: 2.5rem;
+    margin-bottom: var(--space-md);
+}
+
+.changelog-hero__subtitle {
+    font-size: 1.1rem;
+    color: var(--gray-600);
+    margin-bottom: var(--space-sm);
+}
+
+.changelog-hero__note {
+    font-size: 0.95rem;
+    color: var(--gray-500);
+}
+
+.changelog-hero__note a {
+    text-decoration: underline;
+}
+
+.changelog-content {
+    padding: var(--space-3xl) 0;
+}
+
+.changelog-guidelines {
+    background: var(--gray-50);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: var(--space-xl);
+    margin-bottom: var(--space-2xl);
+}
+
+.changelog-guidelines h2 {
+    font-size: 1.5rem;
+    margin-bottom: var(--space-md);
+}
+
+.changelog-guidelines ul {
+    list-style: disc inside;
+    color: var(--gray-600);
+    line-height: 1.7;
+}
+
+.changelog-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xl);
+}
+
+.changelog-date__title {
+    font-size: 1.75rem;
+    margin-bottom: var(--space-lg);
+}
+
+.changelog-date__commits {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+}
+
+.changelog-entry {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: var(--space-xl);
+    box-shadow: var(--shadow-sm);
+}
+
+.changelog-entry__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-md);
+}
+
+.changelog-entry__title {
+    font-size: 1.35rem;
+}
+
+.changelog-entry__meta {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--gray-500);
+}
+
+.changelog-entry__description {
+    color: var(--gray-600);
+    margin-bottom: var(--space-md);
+}
+
+.changelog-entry__changes {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.changelog-entry__change a {
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    word-break: break-word;
+}
+
+.change-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2rem 0.6rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-radius: 999px;
+    margin-right: var(--space-sm);
+}
+
+.change-badge--added {
+    background: rgba(16, 185, 129, 0.15);
+    color: var(--success);
+}
+
+.change-badge--updated {
+    background: rgba(59, 130, 246, 0.15);
+    color: var(--primary);
+}
+
+.change-badge--removed {
+    background: rgba(239, 68, 68, 0.15);
+    color: var(--error);
+}
+
+.change-badge--renamed {
+    background: rgba(245, 158, 11, 0.15);
+    color: var(--warning);
+}
+
+@media (max-width: 768px) {
+    .changelog-page {
+        padding-top: 100px;
+    }
+
+    .changelog-hero__title {
+        font-size: 2rem;
+    }
+
+    .changelog-hero__subtitle {
+        font-size: 1rem;
+    }
+
+    .changelog-entry {
+        padding: var(--space-lg);
+    }
+
+    .changelog-entry__title {
+        font-size: 1.2rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated changelog.html page that renders every non-merge commit grouped by date with file-level links and status badges
- extend the global styles to support the changelog hero, timeline layout, and badge treatments
- surface the changelog from the home page navigation and footer for easy discovery

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d06179776c8325954f74a71d0c35f5