### PR TITLE
Add cross-link navigation between tracker apps

### DIFF
--- a/Apps/hydration-tracker.html
+++ b/Apps/hydration-tracker.html
@@ -24,6 +24,16 @@
 <body class="bg-gray-100 text-gray-800 flex items-center justify-center min-h-screen p-4">
 
     <div class="w-full max-w-md mx-auto bg-white rounded-2xl shadow-xl p-6 md:p-8">
+        <nav class="mb-6">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <a href="hydration-tracker.html" aria-current="page" class="block w-full text-center px-4 py-2 rounded-lg font-semibold bg-blue-600 text-white shadow">
+                    Hydration Tracker
+                </a>
+                <a href="weight-tracker.html" class="block w-full text-center px-4 py-2 rounded-lg font-semibold bg-white text-blue-600 border border-blue-200 hover:bg-blue-50 transition-colors">
+                    Weight Tracker
+                </a>
+            </div>
+        </nav>
         <header class="text-center mb-6">
             <h1 class="text-3xl font-bold text-blue-600">Public Hydration Tracker</h1>
             <p class="text-gray-500 mt-1">A shared goal to rehydrate smart, together.</p>

--- a/Apps/weight-tracker.html
+++ b/Apps/weight-tracker.html
@@ -414,6 +414,16 @@
 <body class="bg-gray-50">
 
     <div class="container mx-auto p-4 sm:p-6 lg:p-8 max-w-2xl">
+        <nav class="mb-6">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <a href="hydration-tracker.html" class="block w-full text-center px-4 py-2 rounded-lg font-semibold bg-white text-blue-600 border border-blue-200 hover:bg-blue-50 transition-colors">
+                    Hydration Tracker
+                </a>
+                <a href="weight-tracker.html" aria-current="page" class="block w-full text-center px-4 py-2 rounded-lg font-semibold bg-blue-600 text-white shadow">
+                    Weight Tracker
+                </a>
+            </div>
+        </nav>
         <header class="text-center mb-8">
             <h1 class="text-4xl font-bold text-gray-800">Weight Tracker</h1>
             <p class="text-gray-600 mt-2">Log your weight and track your progress towards 170 lbs.</p>


### PR DESCRIPTION
## Summary
- add Tailwind navigation cards to the hydration tracker for switching between trackers
- mirror the navigation panel in the weight tracker with active-page styling

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d066d66f508325af899516ab75206b