### PR TITLE
Add Mermaid diagram visualizer app

### DIFF
--- a/Apps/index.html
+++ b/Apps/index.html
@@ -41,7 +41,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <h1 class="text-5xl md:text-6xl font-bold mb-6">App Gallery</h1>
             <p class="text-xl md:text-2xl text-blue-100 max-w-3xl mx-auto mb-8">
-                Discover 28+ productivity, health, and knowledge management apps built to enhance your daily life
+                Discover 29+ productivity, health, and knowledge management apps built to enhance your daily life
             </p>
             <div class="flex flex-wrap justify-center gap-4 text-sm">
                 <span class="bg-white bg-opacity-20 px-4 py-2 rounded-full">Productivity</span>
@@ -57,7 +57,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="grid grid-cols-1 md:grid-cols-4 gap-8 text-center">
                 <div>
-                    <div class="text-4xl font-bold text-blue-600 mb-2">28</div>
+                    <div class="text-4xl font-bold text-blue-600 mb-2">29</div>
                     <div class="text-gray-600">Total Apps</div>
                 </div>
                 <div>
@@ -117,6 +117,24 @@
                                 <span class="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded">Clipboard</span>
                             </div>
                             <a href="html-source-code-viewer.html" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">Launch</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="app-card bg-white rounded-xl shadow-md overflow-hidden">
+                    <div class="p-6">
+                        <div class="flex items-center justify-between mb-4">
+                            <span class="category-badge bg-purple-100 text-purple-800 text-xs font-medium px-3 py-1 rounded-full">Visualization</span>
+                            <span class="text-gray-500 text-sm">New</span>
+                        </div>
+                        <h3 class="text-xl font-bold text-gray-900 mb-2">Mermaid Diagram Visualizer</h3>
+                        <p class="text-gray-600 mb-4">Draft Mermaid syntax, switch themes, and export polished diagrams for docs, workshops, and architecture reviews in seconds.</p>
+                        <div class="flex items-center justify-between">
+                            <div class="flex space-x-2">
+                                <span class="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded">Diagramming</span>
+                                <span class="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded">Developer Tools</span>
+                                <span class="bg-gray-100 text-gray-700 text-xs px-2 py-1 rounded">SVG</span>
+                            </div>
+                            <a href="mermaid-diagram-visualizer.html" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors">Launch</a>
                         </div>
                     </div>
                 </div>

--- a/Apps/mermaid-diagram-visualizer.html
+++ b/Apps/mermaid-diagram-visualizer.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mermaid Diagram Visualizer</title>
+    <meta name="description" content="Interactive Mermaid diagram playground to sketch, preview, and share sequence diagrams, flowcharts, and more.">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background: radial-gradient(circle at top, rgba(102, 126, 234, 0.08), transparent 55%), #f3f4f6;
+        }
+        ::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #e5e7eb;
+            border-radius: 9999px;
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #9ca3af;
+            border-radius: 9999px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #6b7280;
+        }
+        .glass-card {
+            background: rgba(255, 255, 255, 0.82);
+            backdrop-filter: blur(16px);
+        }
+    </style>
+</head>
+<body class="min-h-screen py-6 px-4 md:px-8">
+    <div class="max-w-6xl mx-auto space-y-8">
+        <div class="flex items-center justify-between">
+            <a href="/Apps/index.html" class="inline-flex items-center text-sm font-semibold text-indigo-600 hover:text-indigo-700 transition">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+                Back to App Gallery
+            </a>
+            <span class="text-xs font-medium tracking-wide text-gray-500 uppercase">Version 1.0</span>
+        </div>
+
+        <header class="glass-card rounded-3xl shadow-xl border border-white/60 p-8 md:p-12">
+            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-8">
+                <div class="space-y-4">
+                    <p class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-500">
+                        <span class="block h-2 w-2 rounded-full bg-indigo-500 animate-pulse"></span>
+                        Diagram Studio
+                    </p>
+                    <h1 class="text-4xl md:text-5xl font-bold text-gray-900 leading-tight">Mermaid Diagram Visualizer</h1>
+                    <p class="text-lg text-gray-600 max-w-2xl">Bring sequence diagrams, flowcharts, mind maps, and architecture charts to life. Paste Mermaid markup, preview the visualization instantly, and export the output for documentation or presentations.</p>
+                    <div class="flex flex-wrap gap-3 text-xs font-medium">
+                        <span class="px-3 py-1 rounded-full bg-indigo-100 text-indigo-700">Live Preview</span>
+                        <span class="px-3 py-1 rounded-full bg-violet-100 text-violet-700">Diagram Library</span>
+                        <span class="px-3 py-1 rounded-full bg-sky-100 text-sky-700">Share Ready</span>
+                    </div>
+                </div>
+                <div class="flex-1">
+                    <div class="glass-card rounded-2xl border border-white/60 p-6 shadow-lg">
+                        <h2 class="text-sm font-semibold text-gray-900 uppercase tracking-wide mb-3">Quickstart</h2>
+                        <ul class="space-y-3 text-sm text-gray-600">
+                            <li class="flex items-start gap-3">
+                                <span class="mt-1 h-2 w-2 rounded-full bg-indigo-500"></span>
+                                Paste or write Mermaid syntax in the editor.
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <span class="mt-1 h-2 w-2 rounded-full bg-indigo-500"></span>
+                                Click <strong>Render Diagram</strong> or press <kbd class="px-2 py-1 bg-gray-100 rounded">Ctrl / Cmd + Enter</kbd> to update the visualization.
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <span class="mt-1 h-2 w-2 rounded-full bg-indigo-500"></span>
+                                Save or copy the generated SVG for docs, decks, or handoffs.
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </header>
+
+        <main class="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-6">
+            <section class="glass-card rounded-3xl border border-white/60 shadow-xl overflow-hidden">
+                <div class="border-b border-white/60 bg-white/70 px-6 py-4 flex items-center justify-between">
+                    <div>
+                        <h2 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Mermaid Editor</h2>
+                        <p class="text-xs text-gray-500">Draft your diagram with real-time validation.</p>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <button id="resetBtn" class="px-3 py-1.5 text-xs font-semibold text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition">Reset Sample</button>
+                        <button id="copyBtn" class="px-3 py-1.5 text-xs font-semibold text-white bg-gray-900 rounded-lg hover:bg-gray-700 transition">Copy Code</button>
+                    </div>
+                </div>
+                <div class="p-6">
+                    <textarea id="mermaidInput" class="w-full h-80 md:h-[28rem] resize-none bg-white/80 border border-gray-200 rounded-2xl p-4 text-sm leading-relaxed text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 shadow-inner" spellcheck="false"></textarea>
+                    <div class="mt-4 flex flex-col sm:flex-row sm:items-center gap-3">
+                        <button id="renderBtn" class="flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-3 text-sm font-semibold text-white bg-indigo-600 rounded-xl shadow-lg shadow-indigo-500/30 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 4v16m0 0h16M4 20l4-8 4 4 4-8 4 6" />
+                            </svg>
+                            Render Diagram
+                        </button>
+                        <button id="downloadBtn" class="flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-3 text-sm font-semibold text-indigo-600 bg-indigo-50 rounded-xl hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3" />
+                            </svg>
+                            Download SVG
+                        </button>
+                        <span id="statusMessage" class="text-sm text-gray-500 flex-1"></span>
+                    </div>
+                </div>
+            </section>
+
+            <section class="glass-card rounded-3xl border border-white/60 shadow-xl overflow-hidden flex flex-col">
+                <div class="border-b border-white/60 bg-white/70 px-6 py-4 flex items-center justify-between">
+                    <div>
+                        <h2 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Diagram Preview</h2>
+                        <p class="text-xs text-gray-500">Rendered using the latest Mermaid engine.</p>
+                    </div>
+                    <button id="themeToggle" class="px-3 py-1.5 text-xs font-semibold text-indigo-600 bg-indigo-50 rounded-lg hover:bg-indigo-100 transition">Switch Theme</button>
+                </div>
+                <div class="flex-1 relative">
+                    <div id="diagramContainer" class="h-full overflow-auto p-6 bg-white/80">
+                        <div id="diagramPreview" class="flex items-center justify-center min-h-[22rem] text-gray-400 text-sm text-center">
+                            Render a diagram to see the visualization.
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <section class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="glass-card rounded-2xl border border-white/60 p-5 shadow-lg">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide mb-2">Snippets Library</h3>
+                <p class="text-sm text-gray-600">Tap to load templates for flowcharts, Kanban boards, Gantt charts, and sequence diagrams.</p>
+                <div id="snippets" class="mt-3 flex flex-wrap gap-2"></div>
+            </div>
+            <div class="glass-card rounded-2xl border border-white/60 p-5 shadow-lg">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide mb-2">Keyboard Shortcuts</h3>
+                <ul class="text-sm text-gray-600 space-y-2">
+                    <li><kbd class="px-2 py-1 bg-gray-100 rounded">Ctrl / Cmd + Enter</kbd> — Render Diagram</li>
+                    <li><kbd class="px-2 py-1 bg-gray-100 rounded">Ctrl / Cmd + L</kbd> — Load Next Snippet</li>
+                    <li><kbd class="px-2 py-1 bg-gray-100 rounded">Ctrl / Cmd + Shift + S</kbd> — Download SVG</li>
+                </ul>
+            </div>
+            <div class="glass-card rounded-2xl border border-white/60 p-5 shadow-lg">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide mb-2">Why Mermaid?</h3>
+                <p class="text-sm text-gray-600">Declarative syntax keeps teams aligned. Store diagrams in Git, generate docs on the fly, and collaborate without heavyweight design tools.</p>
+            </div>
+        </section>
+
+        <footer class="text-center text-xs text-gray-500 py-6">
+            Built by Chris Cruz • <a href="https://chriscruz.ai" class="text-indigo-500 hover:text-indigo-400" target="_blank" rel="noopener">chriscruz.ai</a>
+        </footer>
+    </div>
+
+    <script>
+        const mermaidInput = document.getElementById('mermaidInput');
+        const renderBtn = document.getElementById('renderBtn');
+        const resetBtn = document.getElementById('resetBtn');
+        const copyBtn = document.getElementById('copyBtn');
+        const downloadBtn = document.getElementById('downloadBtn');
+        const statusMessage = document.getElementById('statusMessage');
+        const diagramPreview = document.getElementById('diagramPreview');
+        const themeToggle = document.getElementById('themeToggle');
+        const snippetsContainer = document.getElementById('snippets');
+
+        const snippets = [
+            {
+                label: 'User Journey',
+                code: `journey\n    title User journey for growth experiment\n    section Awareness\n      Organic search: 5: Passive\n      LinkedIn Ads: 3: Curious\n    section Activation\n      Landing page: 4: Engaged\n      Product tour: 3: Informed\n    section Retention\n      Weekly insights email: 4: Valued\n      Renewal call: 5: Committed`
+            },
+            {
+                label: 'Product Flow',
+                code: `flowchart TD\n    A[Visitor lands on page] --> B{Intent detected?}\n    B -->|Yes| C[Personalized CTA]\n    B -->|No| D[Educational content]\n    C --> E[Trial signup]\n    D --> F[Retargeting drip]\n    E --> G[Onboarding]\n    F --> G`
+            },
+            {
+                label: 'Architecture',
+                code: `graph LR\n    subgraph Edge\n        CDN --> WAF --> LB
+    end\n    subgraph Core\n        LB --> API[API Layer]\n        API --> Queue\n        API --> DB[(Primary DB)]\n        Queue --> Workers\n        Workers --> Cache[(Redis Cache)]\n    end\n    DB --> Replica[(Read Replica)]`
+            },
+            {
+                label: 'Weekly Standup',
+                code: `gantt\n    title Sprint 24 Standup Agenda\n    dateFormat  HH:mm\n    axisFormat  %H:%M\n    section Roundtable\n    Wins        :active, 09:00, 10m\n    Blockers    :crit, 09:10, 10m\n    Metrics     :milestone, 09:20, 5m\n    section Planning\n    Priorities  : 09:25, 15m\n    Demos       : 09:40, 15m`
+            }
+        ];
+
+        let currentTheme = 'default';
+        let snippetIndex = 0;
+
+        const defaultDiagram = `sequenceDiagram\n    participant U as User\n    participant A as Application\n    participant DB as Database\n\n    U->>A: Submit Mermaid diagram\n    A->>A: Validate & render\n    A->>DB: Store snippet (optional)\n    DB-->>A: Confirmation\n    A-->>U: Return visualization`;
+
+        mermaidInput.value = defaultDiagram;
+
+        mermaid.initialize({ startOnLoad: false, theme: currentTheme });
+
+        async function renderDiagram() {
+            const code = mermaidInput.value.trim();
+            if (!code) {
+                setStatus('Enter Mermaid syntax to render a diagram.', 'warning');
+                return;
+            }
+
+            diagramPreview.innerHTML = '<div class="flex flex-col items-center justify-center gap-3 text-indigo-500 animate-pulse py-12"><svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v6l4 2" /></svg><p class="text-sm font-medium">Rendering your diagram...</p></div>';
+
+            try {
+                const { svg } = await mermaid.render('generatedDiagram', code);
+                diagramPreview.innerHTML = svg;
+                setStatus('Diagram updated successfully.', 'success');
+            } catch (error) {
+                console.error(error);
+                diagramPreview.innerHTML = '<div class="text-sm text-red-500 bg-red-50 border border-red-200 rounded-2xl p-4">' +
+                    '<p class="font-semibold">Render error</p>' +
+                    '<p class="text-xs mt-1">' + (error?.message || 'Check your syntax and try again.') + '</p>' +
+                    '</div>';
+                setStatus('Unable to render. Review syntax and retry.', 'error');
+            }
+        }
+
+        function setStatus(message, type) {
+            statusMessage.textContent = message;
+            statusMessage.className = 'flex-1 text-sm ' + (
+                type === 'success' ? 'text-emerald-600' :
+                type === 'error' ? 'text-red-500' :
+                type === 'warning' ? 'text-amber-600' :
+                'text-gray-500'
+            );
+        }
+
+        function resetSample() {
+            mermaidInput.value = defaultDiagram;
+            renderDiagram();
+            setStatus('Sample diagram loaded.', 'success');
+        }
+
+        function copyCode() {
+            navigator.clipboard.writeText(mermaidInput.value).then(() => {
+                setStatus('Mermaid code copied to clipboard.', 'success');
+            }).catch(() => {
+                setStatus('Copy failed. Select and copy manually.', 'error');
+            });
+        }
+
+        function downloadSvg() {
+            const svgElement = diagramPreview.querySelector('svg');
+            if (!svgElement) {
+                setStatus('Render a diagram before downloading.', 'warning');
+                return;
+            }
+            const serializer = new XMLSerializer();
+            const svgBlob = new Blob([serializer.serializeToString(svgElement)], { type: 'image/svg+xml' });
+            const url = URL.createObjectURL(svgBlob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'mermaid-diagram.svg';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+            setStatus('SVG downloaded.', 'success');
+        }
+
+        function switchTheme() {
+            currentTheme = currentTheme === 'default' ? 'forest' : currentTheme === 'forest' ? 'dark' : 'default';
+            mermaid.initialize({ startOnLoad: false, theme: currentTheme });
+            renderDiagram();
+            themeToggle.textContent = `Theme: ${currentTheme.charAt(0).toUpperCase() + currentTheme.slice(1)}`;
+        }
+
+        function loadSnippet(index) {
+            const snippet = snippets[index % snippets.length];
+            mermaidInput.value = snippet.code;
+            renderDiagram();
+            setStatus(`${snippet.label} template loaded.`, 'success');
+        }
+
+        function populateSnippets() {
+            snippets.forEach((snippet, index) => {
+                const button = document.createElement('button');
+                button.textContent = snippet.label;
+                button.className = 'px-3 py-1.5 text-xs font-semibold text-indigo-600 bg-indigo-50 rounded-lg hover:bg-indigo-100 transition';
+                button.addEventListener('click', () => {
+                    snippetIndex = index;
+                    loadSnippet(index);
+                });
+                snippetsContainer.appendChild(button);
+            });
+        }
+
+        renderBtn.addEventListener('click', renderDiagram);
+        resetBtn.addEventListener('click', resetSample);
+        copyBtn.addEventListener('click', copyCode);
+        downloadBtn.addEventListener('click', downloadSvg);
+        themeToggle.addEventListener('click', switchTheme);
+
+        document.addEventListener('keydown', (event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                event.preventDefault();
+                renderDiagram();
+            }
+            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'l') {
+                event.preventDefault();
+                snippetIndex = (snippetIndex + 1) % snippets.length;
+                loadSnippet(snippetIndex);
+            }
+            if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === 's') {
+                event.preventDefault();
+                downloadSvg();
+            }
+        });
+
+        populateSnippets();
+        renderDiagram();
+        themeToggle.textContent = 'Theme: Default';
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a dedicated Mermaid Diagram Visualizer app with live rendering, theme switching, snippets, and export utilities
- update the App Gallery hero stats and add a launch card linking to the new visualizer

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d57b4c4d588325830ce9143c5baec8