### PR TITLE
Add future-state API consumer strategic guidance blog

### DIFF
--- a/blogs/api-consumer-strategic-guidance.html
+++ b/blogs/api-consumer-strategic-guidance.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Future-State First: API Consumer Strategic Guidance | ChrisCruz.ai</title>
+    <meta name="description" content="Learn how API consumers can avoid wasted effort with a future-state-first approach, progressive discovery, and proactive partnership with provider teams.">
+    <meta name="keywords" content="API strategy, consumer guidance, integration planning, future state, partnership model, technical debt prevention">
+    <meta name="author" content="Christopher Manuel Cruz-Guzman">
+    <meta property="og:title" content="Future-State First: API Consumer Strategic Guidance">
+    <meta property="og:description" content="A progressive playbook for API consumers to align with provider roadmaps, prevent rework, and build strategic partnerships.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://chriscruz.ai/blogs/api-consumer-strategic-guidance.html">
+    <meta property="og:image" content="https://chriscruz.ai/images/api-consumer-strategic-guidance.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Future-State First: API Consumer Strategic Guidance">
+    <meta name="twitter:description" content="Progressive guidance for API consumers to engage early, prevent waste, and co-create future-ready integrations.">
+    <meta name="article:published_time" content="2025-02-17T00:00:00Z">
+    <meta name="article:author" content="Christopher Manuel Cruz-Guzman">
+    <meta name="article:section" content="API Strategy">
+    <meta name="article:tag" content="API strategy, integration planning, product partnerships">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #050505;
+            color: #f1f5f9;
+        }
+        .gradient-text {
+            background: linear-gradient(90deg, #38bdf8, #6366f1, #a855f7);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .blog-content {
+            background-color: rgba(15, 23, 42, 0.65);
+            border: 1px solid rgba(148, 163, 184, 0.12);
+            backdrop-filter: blur(18px);
+        }
+        .section-card {
+            background: rgba(15, 23, 42, 0.55);
+            border: 1px solid rgba(148, 163, 184, 0.12);
+        }
+        details {
+            background: rgba(30, 41, 59, 0.65);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            border-radius: 0.75rem;
+            padding: 1.25rem 1.5rem;
+            margin-top: 1rem;
+        }
+        details summary {
+            cursor: pointer;
+            font-weight: 600;
+            color: #38bdf8;
+        }
+        details[open] {
+            border-color: rgba(96, 165, 250, 0.35);
+            box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.15);
+        }
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            border-radius: 9999px;
+            padding: 0.35rem 0.9rem;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            background: rgba(56, 189, 248, 0.15);
+            color: #bae6fd;
+        }
+        .progress-line {
+            height: 1px;
+            background: linear-gradient(90deg, rgba(56, 189, 248, 0.15), rgba(99, 102, 241, 0.5), rgba(168, 85, 247, 0.15));
+        }
+        .grid-card {
+            background: rgba(15, 23, 42, 0.55);
+            border: 1px solid rgba(148, 163, 184, 0.1);
+            transition: transform 0.3s ease, border-color 0.3s ease;
+        }
+        .grid-card:hover {
+            transform: translateY(-4px);
+            border-color: rgba(59, 130, 246, 0.35);
+        }
+        a.inline-link {
+            color: #60a5fa;
+        }
+    </style>
+</head>
+<body class="min-h-screen">
+    <div class="relative overflow-hidden">
+        <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.12),_transparent_55%)]"></div>
+        <header class="relative pt-16 pb-12">
+            <div class="max-w-5xl mx-auto px-6">
+                <span class="badge">Strategic API Consumer Playbook</span>
+                <h1 class="mt-6 text-4xl md:text-5xl font-bold gradient-text">Future-State First: API Consumer Strategic Guidance</h1>
+                <p class="mt-6 text-lg text-slate-300 md:w-4/5">Stop shipping integrations on yesterday's APIs. This guide shows consumer teams how to surface roadmap intel early, align with provider investments, and turn every build into a strategic co-creation opportunity.</p>
+                <div class="mt-8 p-6 rounded-2xl section-card">
+                    <h2 class="text-xl font-semibold text-slate-100">Read this if you are about to start API discovery.</h2>
+                    <p class="mt-3 text-slate-300">In less than 10 minutes you'll have the playbook that kept LRCO from shipping on a retiring version, saved months of rework, and created a direct seat at the table for future capabilities.</p>
+                    <div class="mt-5 flex flex-wrap gap-3 text-sm text-slate-400">
+                        <span>🏁 Time to implement: 2 weeks</span>
+                        <span>🤝 Ideal for: Consumer product & engineering leads</span>
+                        <span>🧭 Core mindset: Future-state first</span>
+                    </div>
+                </div>
+            </div>
+        </header>
+
+        <main class="relative pb-24">
+            <div class="max-w-5xl mx-auto px-6 space-y-16">
+                <section class="blog-content rounded-3xl p-8 md:p-12">
+                    <h2 class="text-2xl font-semibold text-slate-100">Progressive Overview</h2>
+                    <p class="mt-4 text-slate-300">Move through the layers at your own pace. Each section reveals the next level of sophistication so your team can align strategy before writing a line of integration code.</p>
+                    <div class="mt-8 grid gap-6 md:grid-cols-3">
+                        <div class="grid-card rounded-2xl p-6">
+                            <h3 class="text-lg font-semibold text-slate-100">Stage 1 · Awareness</h3>
+                            <p class="mt-3 text-sm text-slate-400">Recognize the risk of building on expiring APIs and establish a future-state-first mindset.</p>
+                        </div>
+                        <div class="grid-card rounded-2xl p-6">
+                            <h3 class="text-lg font-semibold text-slate-100">Stage 2 · Alignment</h3>
+                            <p class="mt-3 text-sm text-slate-400">Structure early discovery, requirement collaboration, and roadmap alignment with provider teams.</p>
+                        </div>
+                        <div class="grid-card rounded-2xl p-6">
+                            <h3 class="text-lg font-semibold text-slate-100">Stage 3 · Activation</h3>
+                            <p class="mt-3 text-sm text-slate-400">Execute as co-builders with shared accountability, continuous feedback, and future-proof delivery.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section>
+                    <h2 class="text-3xl font-semibold text-slate-100">Start with the Challenge</h2>
+                    <p class="mt-4 text-slate-300">Consumer teams often integrate with the first API version they find, unaware of imminent deprecation or richer alternatives already in flight. The result: wasted sprints, brittle technical debt, and zero influence on what's coming next.</p>
+                    <div class="progress-line mt-6"></div>
+                    <div class="mt-8 grid gap-6 md:grid-cols-2">
+                        <div class="section-card rounded-2xl p-6">
+                            <h3 class="text-xl font-semibold text-slate-100">The Root Risk</h3>
+                            <p class="mt-3 text-slate-300">Building on a sunset timeline or skipping emerging capabilities because nobody asked "What does the future state look like?"</p>
+                        </div>
+                        <div class="section-card rounded-2xl p-6">
+                            <h3 class="text-xl font-semibold text-slate-100">The Mindset Shift</h3>
+                            <p class="mt-3 text-slate-300">Before you write code, investigate the provider's strategic roadmap and invite them in as partners.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section>
+                    <h2 class="text-3xl font-semibold text-slate-100">Progressive Guidance Model</h2>
+                    <p class="mt-4 text-slate-300">Open each layer to explore the exact questions, actions, and deliverables your team should drive.</p>
+
+                    <details open>
+                        <summary>Phase 1 · Strategic Discovery (Start 2-4 weeks before planning)</summary>
+                        <div class="mt-4 space-y-4 text-slate-300">
+                            <p>Goal: Understand the provider's roadmap before you commit to a version.</p>
+                            <ul class="list-disc list-inside space-y-2">
+                                <li>Contact the API provider team with your use case at a high level.</li>
+                                <li>Ask about current stability, end-of-life plans, and any upcoming versions.</li>
+                                <li>Capture their development timeline, key milestones, and dependencies.</li>
+                                <li>Document opportunities for strategic alignment beyond technical integration.</li>
+                            </ul>
+                        </div>
+                    </details>
+
+                    <details>
+                        <summary>Phase 2 · Detailed Requirements Collaboration (During planning)</summary>
+                        <div class="mt-4 space-y-4 text-slate-300">
+                            <p>Goal: Shape the future version so it ships with what you need.</p>
+                            <ul class="list-disc list-inside space-y-2">
+                                <li>Share use case breakdowns, edge cases, and non-negotiable data fields.</li>
+                                <li>Highlight unique requirements that might need roadmap adjustments.</li>
+                                <li>Align delivery timelines, testing windows, and launch sequencing.</li>
+                                <li>Agree on how you'll exchange updates and surface blockers.</li>
+                            </ul>
+                        </div>
+                    </details>
+
+                    <details>
+                        <summary>Phase 3 · Partnership Integration (During development)</summary>
+                        <div class="mt-4 space-y-4 text-slate-300">
+                            <p>Goal: Deliver together, validate early, and document learnings.</p>
+                            <ul class="list-disc list-inside space-y-2">
+                                <li>Schedule recurring check-ins for status, risks, and decision points.</li>
+                                <li>Run early testing cycles with rapid feedback loops.</li>
+                                <li>Share documentation updates and final readiness sign-off.</li>
+                                <li>Retrospect on the partnership to inform future integrations.</li>
+                            </ul>
+                        </div>
+                    </details>
+                </section>
+
+                <section class="section-card rounded-3xl p-8">
+                    <h2 class="text-3xl font-semibold text-slate-100">Principles that Keep You Future-State First</h2>
+                    <div class="mt-6 grid gap-6 md:grid-cols-2">
+                        <div>
+                            <h3 class="text-xl font-semibold text-slate-100">Constraints Can Create Alignment</h3>
+                            <p class="mt-2 text-slate-300">Treat your own timeline limits as a conversation starter. Often, provider development cycles align with your capacity, creating mutual leverage.</p>
+                        </div>
+                        <div>
+                            <h3 class="text-xl font-semibold text-slate-100">Use Cases Are Your Currency</h3>
+                            <p class="mt-2 text-slate-300">The more detailed and well-articulated your use case inventory, the more influence you have on shaping the roadmap.</p>
+                        </div>
+                        <div>
+                            <h3 class="text-xl font-semibold text-slate-100">Think Beyond Integration</h3>
+                            <p class="mt-2 text-slate-300">You're not buying an API; you're co-creating outcomes. Strong partnerships unlock better support and bespoke solutions.</p>
+                        </div>
+                        <div>
+                            <h3 class="text-xl font-semibold text-slate-100">Early Engagement Prevents Waste</h3>
+                            <p class="mt-2 text-slate-300">A single question asked early can redirect an entire initiative toward the right future-state solution.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section>
+                    <h2 class="text-3xl font-semibold text-slate-100">Watch for These Red Flags</h2>
+                    <p class="mt-4 text-slate-300">Pause and re-engage strategically whenever you notice:</p>
+                    <ul class="mt-6 grid gap-3 md:grid-cols-2 text-slate-300">
+                        <li class="section-card rounded-2xl p-5">The API version is 12+ months old with no recent updates.</li>
+                        <li class="section-card rounded-2xl p-5">Documentation, changelogs, or examples are stale or missing.</li>
+                        <li class="section-card rounded-2xl p-5">Provider partners are surprised you are planning an integration.</li>
+                        <li class="section-card rounded-2xl p-5">You see "modernization" or "strategic initiative" language in their updates.</li>
+                        <li class="section-card rounded-2xl p-5">Your use case is common, but you're the first to request it.</li>
+                    </ul>
+                </section>
+
+                <section class="section-card rounded-3xl p-8">
+                    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+                        <div>
+                            <h2 class="text-3xl font-semibold text-slate-100">Success Pattern: LRCO and the Transaction History API</h2>
+                            <p class="mt-4 text-slate-300">September 2025 became the blueprint for partnership done right.</p>
+                        </div>
+                        <div class="text-sm text-slate-400">
+                            <p>Situation → Action → Result → Lesson</p>
+                        </div>
+                    </div>
+                    <div class="mt-6 grid gap-6 md:grid-cols-2">
+                        <div class="bg-slate-900/60 rounded-2xl p-6 border border-slate-700/40">
+                            <h3 class="text-xl font-semibold text-slate-100">What Happened</h3>
+                            <p class="mt-3 text-slate-300">LRCO was preparing to integrate V3 when they surfaced that V4 was already in development as part of the DDA-going-primary initiative.</p>
+                            <p class="mt-3 text-slate-300">They switched from reactive planning to proactive partnership in less than two weeks.</p>
+                        </div>
+                        <div class="bg-slate-900/60 rounded-2xl p-6 border border-slate-700/40">
+                            <h3 class="text-xl font-semibold text-slate-100">Why It Worked</h3>
+                            <ul class="mt-3 list-disc list-inside space-y-2 text-slate-300">
+                                <li>Early inquiry on roadmap direction.</li>
+                                <li>Detailed field-level requirements shared via JIRAs.</li>
+                                <li>Timeline alignment matched LRCO's 2026 migration windows.</li>
+                                <li>Shared commitment to build V4 for day-one readiness.</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <p class="mt-6 text-slate-300">Result: No wasted sprints on V3, zero technical debt, and a strategic seat at the V4 roadmap table.</p>
+                </section>
+
+                <section>
+                    <h2 class="text-3xl font-semibold text-slate-100">Email Template: Kick Off the Partnership</h2>
+                    <p class="mt-4 text-slate-300">Use this to contact the provider team. Customize the placeholders, send it before planning starts, and follow up with a working session invite.</p>
+                    <div class="mt-6 bg-slate-900/70 border border-slate-700/40 rounded-2xl p-6">
+                        <p class="text-sm font-medium uppercase tracking-widest text-slate-400">Subject</p>
+                        <p class="mt-2 text-slate-100 font-semibold">Strategic Integration Planning – [API Name] for [Your Use Case]</p>
+                        <div class="mt-5 space-y-4 text-slate-300">
+                            <p>Hi [Provider Partner Name],</p>
+                            <p>We're planning to enable <strong>[your use case]</strong> and want to align with your roadmap before we commit to a version. Our current timeline has discovery starting in <strong>[month]</strong> with development in <strong>[month]</strong>.</p>
+                            <p>Could you share your strategic outlook for the <strong>[API family]</strong> over the next 12-18 months? We're specifically looking to understand:</p>
+                            <ul class="list-disc list-inside space-y-1">
+                                <li>Long-term viability of the current version.</li>
+                                <li>Upcoming releases or modernization efforts.</li>
+                                <li>Opportunities to align our requirements with future capabilities.</li>
+                            </ul>
+                            <p>If you're open, let's schedule a partnership session where we can walk through our use cases, field-level needs, and timing so we co-create the right solution from day one.</p>
+                            <p>Looking forward to collaborating,<br>[Your Name]<br>[Role / Team]</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="section-card rounded-3xl p-8">
+                    <h2 class="text-3xl font-semibold text-slate-100">Implementation Checklist</h2>
+                    <p class="mt-4 text-slate-300">Embed this workflow into your annual planning cycle and revisit it every quarter.</p>
+                    <div class="mt-6 grid gap-6 md:grid-cols-2">
+                        <ul class="space-y-3 text-slate-300">
+                            <li><input type="checkbox" disabled class="mr-2">Identify all planned API integrations for the next 12 months.</li>
+                            <li><input type="checkbox" disabled class="mr-2">Research provider teams, version maturity, and roadmap language.</li>
+                            <li><input type="checkbox" disabled class="mr-2">Schedule strategic discovery sessions for each high-impact API.</li>
+                        </ul>
+                        <ul class="space-y-3 text-slate-300">
+                            <li><input type="checkbox" disabled class="mr-2">Document detailed use cases and field-level requirements.</li>
+                            <li><input type="checkbox" disabled class="mr-2">Establish recurring communication cadences with provider teams.</li>
+                            <li><input type="checkbox" disabled class="mr-2">Review learnings and update the future-state-first playbook quarterly.</li>
+                        </ul>
+                    </div>
+                </section>
+
+                <section>
+                    <h2 class="text-3xl font-semibold text-slate-100">Organizational Wins You Can Quantify</h2>
+                    <div class="mt-6 grid gap-6 md:grid-cols-2">
+                        <div class="section-card rounded-2xl p-6">
+                            <h3 class="text-xl font-semibold text-slate-100">Reduced Technical Debt</h3>
+                            <p class="mt-3 text-slate-300">Shipping on future-ready APIs from day one eliminates rework cycles triggered by deprecations.</p>
+                        </div>
+                        <div class="section-card rounded-2xl p-6">
+                            <h3 class="text-xl font-semibold text-slate-100">Strategic Partnerships</h3>
+                            <p class="mt-3 text-slate-300">Provider teams become collaborators, unlocking faster support and tailored capabilities.</p>
+                        </div>
+                        <div class="section-card rounded-2xl p-6">
+                            <h3 class="text-xl font-semibold text-slate-100">Resource Efficiency</h3>
+                            <p class="mt-3 text-slate-300">Avoid duplicate integrations by aligning with modernization roadmaps early.</p>
+                        </div>
+                        <div class="section-card rounded-2xl p-6">
+                            <h3 class="text-xl font-semibold text-slate-100">Increased Influence</h3>
+                            <p class="mt-3 text-slate-300">Bring well-documented use cases to shape the backlog and prioritize your needs.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="section-card rounded-3xl p-8">
+                    <h2 class="text-3xl font-semibold text-slate-100">Strategic Questions Answered</h2>
+                    <div class="mt-6 space-y-6 text-slate-300">
+                        <div>
+                            <h3 class="text-xl font-semibold text-slate-100">1. LRCO: V3 or V4?</h3>
+                            <p>Answer: Skip V3, align with V4. The roadmap confirmed Q2 2026 readiness that matches LRCO's migration window.</p>
+                        </div>
+                        <div>
+                            <h3 class="text-xl font-semibold text-slate-100">2. API Provider Team: What do you need?</h3>
+                            <p>Response: Detailed use cases, field-level requirements, and insight into unique constraints so the roadmap serves real-world demand.</p>
+                        </div>
+                        <div>
+                            <h3 class="text-xl font-semibold text-slate-100">3. Organization: How do we make this repeatable?</h3>
+                            <p>Solution: Institutionalize the future-state-first model, document every interaction, and create feedback loops between consumer and provider teams.</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section>
+                    <h2 class="text-3xl font-semibold text-slate-100">Ready to Activate?</h2>
+                    <p class="mt-4 text-slate-300">Embed this playbook into your product development rituals. Kick off each integration with the email template above, log every roadmap insight, and turn every API build into a co-created strategic win.</p>
+                    <p class="mt-4 text-slate-300">Need facilitation support? <a class="inline-link" href="mailto:hello@chriscruz.ai">Reach out</a> and we'll help you build the Future-State First operating rhythm.</p>
+                </section>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -182,6 +182,24 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">API Strategy</span>
+                            <span class="text-xs text-gray-500">Feb 17, 2025</span>
+                        </div>
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="api-consumer-strategic-guidance.html" class="hover:text-indigo-400 transition-colors">
+                                Future-State First: API Consumer Strategic Guidance
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            Progressive disclosure playbook showing consumer teams how to engage providers early, avoid end-of-life APIs, and co-create future-ready integrations.
+                        </p>
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-500">📚 8 min read</span>
+                            <a href="api-consumer-strategic-guidance.html" class="text-indigo-400 hover:underline">Read →</a>
+                        </div>
+                    </article>
+                    <article class="blog-card p-6 rounded-xl">
+                        <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">Release Management</span>
                             <span class="text-xs text-gray-500">Sep 25, 2025</span>
                         </div>


### PR DESCRIPTION
## Summary
- add a new progressive-disclosure blog article for API consumers that emphasizes future-state-first planning, partnership engagement, and includes an outreach email template
- update the blogs index to feature the new guidance post in the latest posts grid

## Testing
- no automated tests were run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d5e64d493c832580a1ef501c3ca49b