### PR TITLE
Add blog covering free Google AI tools

### DIFF
--- a/blogs/beyond-gemini-5-surprising-free-google-ai-tools.html
+++ b/blogs/beyond-gemini-5-surprising-free-google-ai-tools.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Beyond Gemini: 5 Surprising Free Google AI Tools You Can Use Today | ChrisCruz.ai</title>
+    <meta name="description" content="Discover five unexpected, no-cost Google AI capabilities—from app builders to YouTube copilots—and how to integrate them into your workflow using progressive summarization.">
+    <meta name="keywords" content="Google AI, Gemini, Notebook LM, Google AI Studio, Opal, Firebase Studio, Gemini Sheets, YouTube AI, progressive summarization">
+    <meta name="author" content="Christopher Manuel Cruz-Guzman">
+    <meta property="og:title" content="Beyond Gemini: 5 Surprising Free Google AI Tools You Can Use Today">
+    <meta property="og:description" content="Skip the hype and get hands-on with five powerful, lesser-known Google AI tools available at zero cost.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://chriscruz.ai/blogs/beyond-gemini-5-surprising-free-google-ai-tools.html">
+    <meta property="og:image" content="https://chriscruz.ai/images/beyond-gemini-google-ai-tools.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Beyond Gemini: 5 Surprising Free Google AI Tools You Can Use Today">
+    <meta name="twitter:description" content="Discover five unexpected, no-cost Google AI capabilities—from app builders to YouTube copilots—and how to deploy them today.">
+    <meta name="article:published_time" content="2025-02-17T00:00:00Z">
+    <meta name="article:author" content="Christopher Manuel Cruz-Guzman">
+    <meta name="article:section" content="AI Integration">
+    <meta name="article:tag" content="Google AI, Gemini, AI productivity, AI tooling, workflow automation">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #0a0a0a;
+            color: #f0f0f0;
+        }
+        .gradient-text {
+            background: linear-gradient(90deg, #4f46e5, #c026d3, #db2777);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .blog-content {
+            background-color: rgba(255, 255, 255, 0.02);
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(10px);
+        }
+        .summary-box {
+            background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(192, 38, 211, 0.12));
+            border: 1px solid rgba(79, 70, 229, 0.3);
+        }
+        .summary-level {
+            border-left: 4px solid rgba(192, 38, 211, 0.8);
+            background-color: rgba(255, 255, 255, 0.02);
+        }
+        .quote-box {
+            background-color: rgba(255, 255, 255, 0.03);
+            border-left: 4px solid #60a5fa;
+        }
+        .tool-card {
+            background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(59, 130, 246, 0.12));
+            border: 1px solid rgba(59, 130, 246, 0.25);
+        }
+        .step-card {
+            background-color: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+    </style>
+</head>
+<body class="antialiased">
+
+    <!-- Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 bg-black/30 backdrop-blur-md">
+        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="../brand-hub.html" class="text-xl font-bold tracking-tighter">ChrisCruz<span class="text-indigo-400">.ai</span></a>
+            <nav class="hidden md:flex space-x-8">
+                <a href="../brand-hub.html" class="hover:text-indigo-400 transition-colors">Empire</a>
+                <a href="../manifesto.html" class="hover:text-indigo-400 transition-colors">Manifesto</a>
+                <a href="../brand-story.html" class="hover:text-indigo-400 transition-colors">Story</a>
+                <a href="../contact.html" class="hover:text-indigo-400 transition-colors">Contact</a>
+            </nav>
+            <span class="text-xs font-semibold py-1 px-3 rounded-full bg-indigo-500/20 text-indigo-300 border border-indigo-500/30">AI Integration</span>
+        </div>
+    </header>
+
+    <main class="pt-24">
+        <!-- Article Header -->
+        <section class="py-20 px-6">
+            <div class="container mx-auto max-w-4xl">
+                <div class="text-center mb-8">
+                    <div class="flex items-center justify-center space-x-2 mb-4">
+                        <span class="bg-gradient-to-r from-indigo-500 to-purple-600 text-white text-xs font-semibold py-1 px-3 rounded-full">AI Integration</span>
+                        <span class="text-gray-500 text-sm">February 17, 2025</span>
+                        <span class="text-gray-500 text-sm">•</span>
+                        <span class="text-gray-500 text-sm">7 min read</span>
+                    </div>
+                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-black tracking-tighter mb-6">
+                        Beyond Gemini: <span class="gradient-text">5 Surprising Free Google AI Tools</span> You Can Use Today
+                    </h1>
+                    <p class="text-xl text-gray-400 max-w-3xl mx-auto leading-relaxed">
+                        Everyone is staring at Gemini demos. Meanwhile, Google quietly shipped a fleet of free, production-grade AI features that can automate workflows, synthesize research, and turn raw data into next-step playbooks. This is your field guide.
+                    </p>
+                </div>
+
+                <div class="flex items-center justify-center space-x-4 text-sm text-gray-500">
+                    <div class="flex items-center space-x-2">
+                        <div class="w-10 h-10 bg-gradient-to-r from-indigo-500 to-purple-600 rounded-full flex items-center justify-center text-white font-bold">CC</div>
+                        <span>Christopher Manuel Cruz-Guzman</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Article Content -->
+        <section class="py-20 px-6">
+            <div class="container mx-auto max-w-4xl">
+                <article class="blog-content p-8 md:p-12 rounded-2xl space-y-12">
+
+                    <div class="summary-box p-6 rounded-xl space-y-4">
+                        <h2 class="text-2xl font-bold text-white">Progressive Summaries</h2>
+                        <div class="summary-level p-4 rounded-lg">
+                            <h3 class="text-sm uppercase tracking-wide text-purple-300 mb-2">Level 1 · TL;DR Signal</h3>
+                            <p class="text-gray-200 text-base">Google’s free AI arsenal already lets you build apps, generate multimedia research packages, orchestrate multimodal experiments, translate spreadsheet data into strategies, and interrogate any YouTube video. You can deploy all five today without touching a single invoice.</p>
+                        </div>
+                        <div class="summary-level p-4 rounded-lg">
+                            <h3 class="text-sm uppercase tracking-wide text-purple-300 mb-2">Level 2 · Key Moves</h3>
+                            <ul class="list-disc list-inside text-gray-200 space-y-2">
+                                <li>Describe workflows in plain language and watch Opal, Google AI Studio App Builder, or Firebase Studio ship functional apps.</li>
+                                <li>Feed Notebook LM mixed media to generate mind maps, podcasts, videos, and study kits from the same research pile.</li>
+                                <li>Use Google AI Studio as an experimentation lab—compare Gemini models, tweak temperature, and generate images, videos, or narration.</li>
+                                <li>Prompt Gemini inside Google Sheets to transform survey data into implementation roadmaps with zero formulas.</li>
+                                <li>Tap the YouTube “Ask” button to chat with any video, surface chapters, and capture the exact answers you need in seconds.</li>
+                            </ul>
+                        </div>
+                        <div class="summary-level p-4 rounded-lg">
+                            <h3 class="text-sm uppercase tracking-wide text-purple-300 mb-2">Level 3 · Field Notes</h3>
+                            <p class="text-gray-300 text-base leading-relaxed">Each tool becomes a node in a wider workflow: prototype the idea in Opal, document the research in Notebook LM, stress-test prompts and media in AI Studio, convert the raw survey results into a go-to-market checklist in Sheets, and publish a YouTube explainer with on-demand Q&amp;A support. The stack is already enterprise-grade—the only missing ingredient is telling it what to do.</p>
+                        </div>
+                    </div>
+
+                    <section class="space-y-8">
+                        <h2 class="text-3xl font-bold text-indigo-300">1. Build Apps Without Writing a Single Line of Code</h2>
+                        <p class="text-lg text-gray-300 leading-relaxed">Google quietly assembled three zero-code launch pads. You describe the intent; they produce shippable workflows, interfaces, or even full-stack apps. It’s rapid prototyping without the weekend hackathon hangover.</p>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                            <div class="tool-card p-6 rounded-xl">
+                                <h3 class="font-semibold text-lg text-white mb-3">Opal Mini-Apps</h3>
+                                <p class="text-sm text-gray-200 leading-relaxed">Drop in natural language (“Optimize this blog post for SEO and publish to Docs”) and Opal strings together the workflow—input capture, optimization routines, export steps—within a shareable mini-app.</p>
+                            </div>
+                            <div class="tool-card p-6 rounded-xl">
+                                <h3 class="font-semibold text-lg text-white mb-3">AI Studio App Builder</h3>
+                                <p class="text-sm text-gray-200 leading-relaxed">One sentence of intent kicks off planning, code generation, and UI assembly. In roughly 90 seconds, you’re clicking through a usable interface built entirely by Gemini.</p>
+                            </div>
+                            <div class="tool-card p-6 rounded-xl">
+                                <h3 class="font-semibold text-lg text-white mb-3">Firebase Studio "Vibe Coding"</h3>
+                                <p class="text-sm text-gray-200 leading-relaxed">Describe the vibe—“turn this landing page into a product waitlist with animated hero copy”—and Firebase Studio rewrites the layout, styles, and backend hooks on command.</p>
+                            </div>
+                        </div>
+                        <div class="quote-box p-6 rounded-xl text-lg text-gray-100 italic">
+                            “Literally in about 90 seconds it created this app… I have no idea how to code. All I did was describe what I wanted and it built it.”
+                        </div>
+                        <div class="step-card p-6 rounded-xl space-y-3">
+                            <h3 class="text-sm uppercase tracking-wide text-gray-400">Deployment Play</h3>
+                            <ol class="list-decimal list-inside text-gray-300 space-y-2">
+                                <li>Draft the job-to-be-done in natural language (“Prototype a lead intake tracker that emails me daily summaries”).</li>
+                                <li>Spin it up in Opal for workflow logic, or in AI Studio/Firebase Studio if you need hosted UI.</li>
+                                <li>Export assets into Google Docs, Sites, or Firebase Hosting and invite your team to stress-test within hours.</li>
+                            </ol>
+                        </div>
+                    </section>
+
+                    <section class="space-y-8">
+                        <h2 class="text-3xl font-bold text-indigo-300">2. Notebook LM Turns Research into a Multimedia Studio</h2>
+                        <p class="text-lg text-gray-300 leading-relaxed">Notebook LM stopped being a simple summarizer. Feed it PDFs, Google Docs, URLs, or YouTube videos and it becomes a creative director that outputs structured thinking artifacts.</p>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div class="step-card p-6 rounded-xl space-y-3">
+                                <h3 class="font-semibold text-white">Mind Maps &amp; Study Kits</h3>
+                                <p class="text-sm text-gray-300">Automatically chart the themes, surface key quotes, and assemble quizzes or flashcards for team workshops or exam preps.</p>
+                            </div>
+                            <div class="step-card p-6 rounded-xl space-y-3">
+                                <h3 class="font-semibold text-white">Audio &amp; Video Overviews</h3>
+                                <p class="text-sm text-gray-300">Spin up podcast-style narratives or explainer videos with chosen tones—briefing, deep dive, critique, or point-counterpoint debates.</p>
+                            </div>
+                        </div>
+                        <p class="text-lg text-gray-300 leading-relaxed">The real unlock is iteration speed. Upload your research binder once. Then remix it into sales enablement clips, leadership briefings, or onboarding quizzes without rewriting the source.</p>
+                    </section>
+
+                    <section class="space-y-8">
+                        <h2 class="text-3xl font-bold text-indigo-300">3. Google AI Studio Is a Free Multimodal Sandbox</h2>
+                        <p class="text-lg text-gray-300 leading-relaxed">Think of Google AI Studio as a control room where you can benchmark models, adjust creativity, and orchestrate multimodal outputs. It’s what the consumer Gemini app hides behind guardrails.</p>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div class="tool-card p-6 rounded-xl">
+                                <h3 class="font-semibold text-lg text-white mb-3">Model Playground</h3>
+                                <p class="text-sm text-gray-200">Compare Gemini 1.5 Pro, Flash, and experimental releases side-by-side to see which one handles your prompts best before you embed them into products.</p>
+                            </div>
+                            <div class="tool-card p-6 rounded-xl">
+                                <h3 class="font-semibold text-lg text-white mb-3">Creative Controls &amp; Media</h3>
+                                <p class="text-sm text-gray-200">Dial temperature, system instructions, or safety settings; generate imagery via Imagen/Nano Banana; and experiment with Veo V3 for text-to-video riffs.</p>
+                            </div>
+                        </div>
+                        <div class="step-card p-6 rounded-xl space-y-3">
+                            <h3 class="text-sm uppercase tracking-wide text-gray-400">Workflow Stack</h3>
+                            <ul class="list-disc list-inside text-gray-300 space-y-2">
+                                <li>Prototype AI assistants and capture prompt templates inside sharable projects.</li>
+                                <li>Generate narration tracks for newsletters or onboarding flows using the speech synthesis endpoint.</li>
+                                <li>Export JSON responses directly into Apps Script, Firebase functions, or API gateways to productionize the experiments.</li>
+                            </ul>
+                        </div>
+                    </section>
+
+                    <section class="space-y-8">
+                        <h2 class="text-3xl font-bold text-indigo-300">4. Gemini in Google Sheets Turns Data into Action</h2>
+                        <p class="text-lg text-gray-300 leading-relaxed">Forget nested formulas. Gemini now lives in Google Sheets so you can type plain English inside any empty cell and reference the rows around it. The output is instant decision support.</p>
+                        <div class="step-card p-6 rounded-xl space-y-3">
+                            <h3 class="font-semibold text-white">Example Prompt</h3>
+                            <p class="text-sm text-gray-300">“Based on the community feedback in column B, give me an action plan with implementation steps to improve engagement next quarter.”</p>
+                            <p class="text-sm text-gray-400">Result: a structured plan with owners, timelines, and impact scores—no formula wizardry required.</p>
+                        </div>
+                        <p class="text-lg text-gray-300 leading-relaxed">The creator who demoed the feature said it “saved me a ton of time.” For operators, it means every dataset can graduate into a next-step playbook without leaving Sheets.</p>
+                    </section>
+
+                    <section class="space-y-8">
+                        <h2 class="text-3xl font-bold text-indigo-300">5. Chat Directly with Any YouTube Video</h2>
+                        <p class="text-lg text-gray-300 leading-relaxed">YouTube’s Gemini “Ask” button transforms video into a conversational knowledge base. You’re no longer scrubbing through timestamps; you’re interrogating the transcript.</p>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div class="tool-card p-6 rounded-xl">
+                                <h3 class="font-semibold text-lg text-white mb-3">Targeted Answers</h3>
+                                <p class="text-sm text-gray-200">Ask follow-ups like “What makes Google Tasks perfect in this workflow?” and receive concise, cited responses drawn straight from the video.</p>
+                            </div>
+                            <div class="tool-card p-6 rounded-xl">
+                                <h3 class="font-semibold text-lg text-white mb-3">Instant Chapters</h3>
+                                <p class="text-sm text-gray-200">Generate a chapter list—even if the creator didn’t add one—so you can jump to the section that actually matters.</p>
+                            </div>
+                        </div>
+                        <p class="text-lg text-gray-300 leading-relaxed">Pair it with Notebook LM to turn video Q&amp;A into study notes or embed the highlights into your next slide deck without manual transcription.</p>
+                    </section>
+
+                    <section class="space-y-8">
+                        <h2 class="text-3xl font-bold text-indigo-300">Conclusion: Your Workflow, Reimagined</h2>
+                        <p class="text-lg text-gray-300 leading-relaxed">The power move is connecting these tools. Prototype the product with AI-native builders, synthesize customer intelligence in Notebook LM, stress-test content in AI Studio, spin operational checklists in Sheets, and give your audience an interactive video companion on YouTube. Google’s ecosystem already functions as a distributed AI operating system—you just have to pilot it.</p>
+                        <div class="step-card p-6 rounded-xl space-y-3">
+                            <h3 class="text-sm uppercase tracking-wide text-gray-400">Next Actions</h3>
+                            <ul class="list-disc list-inside text-gray-300 space-y-2">
+                                <li>Pick one workflow bottleneck and rebuild it with a no-code Google AI tool.</li>
+                                <li>Centralize your research in Notebook LM and pre-generate mind maps plus audio briefings.</li>
+                                <li>Use Sheets + Gemini to convert your latest metrics review into a tactical action plan.</li>
+                                <li>Publish a YouTube walkthrough and enable the Gemini chat so your audience can self-serve answers.</li>
+                            </ul>
+                        </div>
+                    </section>
+
+                </article>
+            </div>
+        </section>
+    </main>
+
+</body>
+</html>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -182,6 +182,24 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                     <article class="blog-card p-6 rounded-xl">
                         <div class="flex items-center space-x-2 mb-4">
+                            <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">AI Integration</span>
+                            <span class="text-xs text-gray-500">Feb 17, 2025</span>
+                        </div>
+                        <h3 class="font-bold text-lg mb-3">
+                            <a href="beyond-gemini-5-surprising-free-google-ai-tools.html" class="hover:text-indigo-400 transition-colors">
+                                Beyond Gemini: 5 Surprising Free Google AI Tools You Can Use Today
+                            </a>
+                        </h3>
+                        <p class="text-sm text-gray-400 mb-4">
+                            Progressive summarization tour of five lesser-known Google AI upgrades—from Opal app builds to YouTube’s Gemini chat—that you can deploy for free right now.
+                        </p>
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-500">📚 7 min read</span>
+                            <a href="beyond-gemini-5-surprising-free-google-ai-tools.html" class="text-indigo-400 hover:underline">Read →</a>
+                        </div>
+                    </article>
+                    <article class="blog-card p-6 rounded-xl">
+                        <div class="flex items-center space-x-2 mb-4">
                             <span class="category-tag text-xs font-semibold py-1 px-3 rounded-full">LifeOS Development</span>
                             <span class="text-xs text-gray-500">Nov 9, 2025</span>
                         </div>


### PR DESCRIPTION
## Summary
- add a new AI Integration blog post that spotlights five free Google AI capabilities using a progressive summarization structure
- feature the article on the blogs index grid with metadata, description, and link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d62307826883258884401e1b4df0e2