### PR TITLE
Remove night mode from Todoist project planner

### DIFF
--- a/Apps/todoist-project-planning.html
+++ b/Apps/todoist-project-planning.html
@@ -42,9 +42,6 @@
         #task-list li:hover {
             background-color: #f0f4ff; /* A light blue hover */
         }
-        .dark #task-list li:hover {
-            background-color: #2d3748; /* A darker hover for dark mode */
-        }
     
         /* Project Planner Styles */
 
@@ -102,84 +99,18 @@
         #natural-planning-section.collapsed .chevron-icon { transform: rotate(-90deg); }
         .settings-tab-content.hidden { display: none; }
 
-        /* Dark mode adjustments for Project Planner */
-        .dark #project-planner-section {
-            color: #f9fafb;
-        }
-        .dark #project-planner-section .text-gray-300 {
-            color: #d1d5db !important;
-        }
-        .dark #project-planner-section .text-gray-400 {
-            color: #9ca3af !important;
-        }
-        .dark #project-planner-section .text-gray-500,
-        .dark #project-planner-section .text-gray-600,
-        .dark #project-planner-section .text-gray-700 {
-            color: #d1d5db !important;
-        }
-        .dark #project-planner-section .text-gray-800,
-        .dark #project-planner-section .text-gray-900 {
-            color: #f9fafb !important;
-        }
-        .dark #project-planner-section .bg-white {
-            background-color: #1f2937 !important;
-        }
-        .dark #project-planner-section .bg-gray-50,
-        .dark #project-planner-section .bg-gray-100,
-        .dark #project-planner-section .bg-gray-200 {
-            background-color: #374151 !important;
-        }
-        .dark #project-planner-section .bg-gray-300 {
-            background-color: #4b5563 !important;
-        }
-        .dark #project-planner-section .bg-slate-50 {
-            background-color: #1e293b !important;
-        }
-        .dark #project-planner-section .border-gray-200,
-        .dark #project-planner-section .border-gray-300 {
-            border-color: #4b5563 !important;
-        }
-        .dark #project-planner-section .view-toggle {
-            background-color: #1f2937 !important;
-            border-color: #4b5563 !important;
-        }
-        .dark #project-planner-section .view-toggle button {
-            color: #d1d5db;
-        }
-        .dark #project-planner-section .view-toggle button.active {
-            color: #ffffff;
-        }
-        .dark #project-planner-section input,
-        .dark #project-planner-section textarea,
-        .dark #project-planner-section select {
-            background-color: #111827;
-            color: #f9fafb;
-            border-color: #4b5563;
-        }
-        .dark #project-planner-section ::placeholder {
-            color: #9ca3af;
-        }
-        .dark #project-planner-section .modal-header {
-            background-color: #111827;
-            border-color: #374151;
-        }
-        .dark #project-planner-section .markdown-view {
-            background-color: #1f2937;
-            border-color: #374151;
-        }
-    
     </style>
 </head>
-<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+<body class="bg-gray-100 text-gray-900">
 
     <div class="max-w-5xl mx-auto px-4 pt-10 pb-6">
-        <div class="bg-white/90 dark:bg-gray-800/80 border border-gray-200 dark:border-gray-700 rounded-3xl shadow-xl p-8 text-center">
-            <h1 class="text-4xl sm:text-5xl font-extrabold text-gray-900 dark:text-white">Todoist Project Planning</h1>
-            <p class="mt-3 text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">Review, sort, and plan Todoist tasks while steering long-term projects in one streamlined workspace.</p>
+        <div class="bg-white/90 border border-gray-200 rounded-3xl shadow-xl p-8 text-center">
+            <h1 class="text-4xl sm:text-5xl font-extrabold text-gray-900">Todoist Project Planning</h1>
+            <p class="mt-3 text-lg text-gray-600 max-w-2xl mx-auto">Review, sort, and plan Todoist tasks while steering long-term projects in one streamlined workspace.</p>
             <div class="mt-6 flex justify-center">
-                <div class="inline-flex bg-gray-100 dark:bg-gray-700 rounded-full p-1 shadow-inner">
-                    <button id="show-sorter-btn" data-section="sorter" class="px-5 py-2 text-sm font-semibold rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-transparent text-gray-600 dark:text-gray-300">Task Sorter</button>
-                    <button id="show-planner-btn" data-section="planner" class="px-5 py-2 text-sm font-semibold rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-transparent text-gray-600 dark:text-gray-300">Project Planner</button>
+                <div class="inline-flex bg-gray-100 rounded-full p-1 shadow-inner">
+                    <button id="show-sorter-btn" data-section="sorter" class="px-5 py-2 text-sm font-semibold rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-transparent text-gray-600">Task Sorter</button>
+                    <button id="show-planner-btn" data-section="planner" class="px-5 py-2 text-sm font-semibold rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 bg-transparent text-gray-600">Project Planner</button>
                 </div>
             </div>
         </div>
@@ -190,27 +121,27 @@
     <div class="container mx-auto p-4 sm:p-6 lg:p-8">
         <!-- Main Task List View -->
         <div id="task-list-view" class="max-w-3xl mx-auto">
-            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
+            <div class="bg-white rounded-xl shadow-lg p-6">
                 <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4">
                     <div class="mb-4 sm:mb-0">
-                        <h1 class="text-2xl font-bold text-gray-800 dark:text-white">Your Todoist Tasks</h1>
-                        <div class="flex space-x-4 mt-2 text-sm text-gray-500 dark:text-gray-400">
+                        <h1 class="text-2xl font-bold text-gray-800">Your Todoist Tasks</h1>
+                        <div class="flex space-x-4 mt-2 text-sm text-gray-500">
                            <p id="kpi-task-count">Total: 0</p>
                            <p id="kpi-reviewed-count">Reviewed: 0 (0%)</p>
                         </div>
                     </div>
                     <div class="flex items-center space-x-2 w-full sm:w-auto">
-                        <button id="refresh-button" class="p-2 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-transform duration-300">
+                        <button id="refresh-button" class="p-2 text-gray-500 hover:bg-gray-100 rounded-full transition-transform duration-300">
                              <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h5M20 20v-5h-5M20 4h-5v5M4 20h5v-5" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 9l-6 6m0-6l6 6" /></svg>
                         </button>
                     </div>
                 </div>
 
                 <!-- Sorting and Filtering Controls -->
-                <div class="flex flex-col sm:flex-row gap-4 mb-4 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                <div class="flex flex-col sm:flex-row gap-4 mb-4 p-4 bg-gray-50 rounded-lg">
                     <div class="flex-1">
-                        <label for="sort-select" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Sort by</label>
-                        <select id="sort-select" class="w-full bg-white dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500">
+                        <label for="sort-select" class="block text-sm font-medium text-gray-700 mb-1">Sort by</label>
+                        <select id="sort-select" class="w-full bg-white border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500">
                             <option value="default">Default</option>
                             <option value="priority">Priority (High to Low)</option>
                             <option value="duration">Duration (Low to High)</option>
@@ -219,8 +150,8 @@
                         </select>
                     </div>
                     <div class="flex-1">
-                        <label for="completion-filter" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Filter by</label>
-                        <select id="completion-filter" class="w-full bg-white dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500">
+                        <label for="completion-filter" class="block text-sm font-medium text-gray-700 mb-1">Filter by</label>
+                        <select id="completion-filter" class="w-full bg-white border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500">
                             <option value="all">All Tasks</option>
                             <option value="incomplete">Incomplete Tasks</option>
                             <option value="complete">Complete Tasks</option>
@@ -240,7 +171,7 @@
 
 
                 <div id="loading-indicator" class="text-center py-8">
-                    <p class="text-lg text-gray-500 dark:text-gray-400">Loading tasks...</p>
+                    <p class="text-lg text-gray-500">Loading tasks...</p>
                 </div>
                 <div id="error-message" class="hidden bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg relative mb-4" role="alert"></div>
                 <ul id="task-list" class="space-y-3 mb-6">
@@ -251,73 +182,73 @@
 
         <!-- Task Review/Editor View -->
         <div id="task-editor-view" class="hidden max-w-2xl mx-auto">
-             <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
+             <div class="bg-white rounded-xl shadow-lg p-6">
                 <!-- Top Navigation -->
                 <div id="editor-top-nav" class="flex justify-between items-center mb-4">
-                    <button id="back-button" class="bg-gray-200 hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500 text-gray-800 dark:text-gray-200 font-bold py-2 px-4 rounded-lg transition duration-300">← Save & Back</button>
+                    <button id="back-button" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg transition duration-300">← Save & Back</button>
                     <button id="next-button" class="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-lg transition duration-300 hidden">Next Task →</button>
                 </div>
 
                 <div id="progress-container" class="mb-6">
                     <div class="flex justify-between items-center mb-1">
-                        <span id="progress-title" class="text-sm font-medium text-gray-700 dark:text-gray-300">Review Progress</span>
-                        <span id="progress-text" class="text-sm font-medium text-gray-700 dark:text-gray-300">0/0 (0%)</span>
+                        <span id="progress-title" class="text-sm font-medium text-gray-700">Review Progress</span>
+                        <span id="progress-text" class="text-sm font-medium text-gray-700">0/0 (0%)</span>
                     </div>
-                    <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-600">
+                    <div class="w-full bg-gray-200 rounded-full h-2.5">
                         <div id="progress-bar" class="bg-blue-600 h-2.5 rounded-full transition-all duration-300" style="width: 0%"></div>
                     </div>
                 </div>
                 
                 <div id="editor-loading" class="text-center py-8 hidden">
-                     <p class="text-lg text-gray-500 dark:text-gray-400">Loading task details...</p>
+                     <p class="text-lg text-gray-500">Loading task details...</p>
                 </div>
 
                 <div id="editor-content" class="space-y-6">
                     <div>
-                        <label for="task-content-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Task</label>
-                        <textarea id="task-content-input" rows="3" class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg p-3 text-lg font-medium focus:ring-2 focus:ring-blue-500 focus:border-blue-500"></textarea>
+                        <label for="task-content-input" class="block text-sm font-medium text-gray-700 mb-1">Task</label>
+                        <textarea id="task-content-input" rows="3" class="w-full bg-gray-50 border border-gray-300 rounded-lg p-3 text-lg font-medium focus:ring-2 focus:ring-blue-500 focus:border-blue-500"></textarea>
                     </div>
                     <div>
-                        <label for="task-description-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description</label>
-                        <textarea id="task-description-input" rows="4" class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg p-3 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"></textarea>
+                        <label for="task-description-input" class="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                        <textarea id="task-description-input" rows="4" class="w-full bg-gray-50 border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"></textarea>
                     </div>
 
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
-                            <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 text-center">Set Device</h3>
+                            <h3 class="text-sm font-medium text-gray-700 mb-3 text-center">Set Device</h3>
                             <div id="device-selector" class="flex justify-center space-x-3 sm:space-x-4">
-                                <button data-label="Computer" class="label-btn font-medium py-2 px-5 rounded-full transition-all duration-200 bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-300">Computer</button>
-                                <button data-label="Phone" class="label-btn font-medium py-2 px-5 rounded-full transition-all duration-200 bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300">Phone</button>
+                                <button data-label="Computer" class="label-btn font-medium py-2 px-5 rounded-full transition-all duration-200 bg-teal-100 text-teal-800">Computer</button>
+                                <button data-label="Phone" class="label-btn font-medium py-2 px-5 rounded-full transition-all duration-200 bg-purple-100 text-purple-800">Phone</button>
                             </div>
                         </div>
                         <div>
-                            <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 text-center">Set Duration</h3>
+                            <h3 class="text-sm font-medium text-gray-700 mb-3 text-center">Set Duration</h3>
                             <div id="duration-selector" class="flex justify-center space-x-2 sm:space-x-3">
-                                <button data-label="5min" class="label-btn font-medium py-2 px-4 rounded-full transition-all duration-200 bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">5m</button>
-                                <button data-label="25min" class="label-btn font-medium py-2 px-4 rounded-full transition-all duration-200 bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300">25m</button>
-                                <button data-label="50min" class="label-btn font-medium py-2 px-4 rounded-full transition-all duration-200 bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-300">50m</button>
+                                <button data-label="5min" class="label-btn font-medium py-2 px-4 rounded-full transition-all duration-200 bg-green-100 text-green-800">5m</button>
+                                <button data-label="25min" class="label-btn font-medium py-2 px-4 rounded-full transition-all duration-200 bg-yellow-100 text-yellow-800">25m</button>
+                                <button data-label="50min" class="label-btn font-medium py-2 px-4 rounded-full transition-all duration-200 bg-pink-100 text-pink-800">50m</button>
                             </div>
                         </div>
                     </div>
 
                     <div>
-                        <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3 text-center">Set Priority</h3>
+                        <h3 class="text-sm font-medium text-gray-700 mb-3 text-center">Set Priority</h3>
                         <div id="priority-selector" class="flex justify-center space-x-3 sm:space-x-4">
-                            <button data-priority="4" class="priority-btn font-bold w-12 h-12 rounded-full transition-all duration-200 bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300">P1</button>
-                            <button data-priority="3" class="priority-btn font-bold w-12 h-12 rounded-full transition-all duration-200 bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300">P2</button>
-                            <button data-priority="2" class="priority-btn font-bold w-12 h-12 rounded-full transition-all duration-200 bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300">P3</button>
-                            <button data-priority="1" class="priority-btn font-bold w-12 h-12 rounded-full transition-all duration-200 bg-gray-200 text-gray-800 dark:bg-gray-600 dark:text-gray-300">P4</button>
+                            <button data-priority="4" class="priority-btn font-bold w-12 h-12 rounded-full transition-all duration-200 bg-red-100 text-red-800">P1</button>
+                            <button data-priority="3" class="priority-btn font-bold w-12 h-12 rounded-full transition-all duration-200 bg-orange-100 text-orange-800">P2</button>
+                            <button data-priority="2" class="priority-btn font-bold w-12 h-12 rounded-full transition-all duration-200 bg-blue-100 text-blue-800">P3</button>
+                            <button data-priority="1" class="priority-btn font-bold w-12 h-12 rounded-full transition-all duration-200 bg-gray-200 text-gray-800">P4</button>
                         </div>
                     </div>
 
                     <!-- AI Assistant Section -->
-                    <div id="ai-assistant-container" class="hidden space-y-2 pt-4 border-t border-gray-200 dark:border-gray-700">
-                        <label for="ai-prompt-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Ask AI to help with this task (Press Enter to submit):</label>
-                        <input type="text" id="ai-prompt-input" placeholder="e.g., 'break this down into sub-tasks'" class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg p-3 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
-                        <p id="ai-status" class="text-sm text-gray-500 dark:text-gray-400 h-5"></p> <!-- h-5 to prevent layout shift -->
+                    <div id="ai-assistant-container" class="hidden space-y-2 pt-4 border-t border-gray-200">
+                        <label for="ai-prompt-input" class="block text-sm font-medium text-gray-700">Ask AI to help with this task (Press Enter to submit):</label>
+                        <input type="text" id="ai-prompt-input" placeholder="e.g., 'break this down into sub-tasks'" class="w-full bg-gray-50 border border-gray-300 rounded-lg p-3 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+                        <p id="ai-status" class="text-sm text-gray-500 h-5"></p> <!-- h-5 to prevent layout shift -->
                     </div>
 
-                    <div id="editor-actions" class="flex flex-wrap justify-between items-center gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <div id="editor-actions" class="flex flex-wrap justify-between items-center gap-3 pt-4 border-t border-gray-200">
                          <div class="flex flex-wrap gap-3">
                              <a id="open-todoist-button" href="#" target="_blank" class="text-center bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg transition duration-300">Open</a>
                              <button id="timer-button" class="bg-emerald-500 hover:bg-emerald-600 text-white font-bold py-2 px-4 rounded-lg transition duration-300 min-w-[110px]">Start Timer</button>
@@ -364,10 +295,10 @@
         </div>
 
         <div id="matrix-view" class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <div class="bg-white rounded-xl shadow-md p-4"><h3 class="text-lg font-bold text-red-600 mb-3 border-b-2 border-red-200 pb-2">Urgent & Important (Do)</h3><div id="quadrant-do" class="eisenhower-quadrant p-2 space-y-3 bg-red-50 dark:bg-red-900/30 rounded-md" data-quadrant="do"></div></div>
-            <div class="bg-white rounded-xl shadow-md p-4"><h3 class="text-lg font-bold text-blue-600 mb-3 border-b-2 border-blue-200 pb-2">Important & Not Urgent (Schedule)</h3><div id="quadrant-schedule" class="eisenhower-quadrant p-2 space-y-3 bg-blue-50 dark:bg-blue-900/30 rounded-md" data-quadrant="schedule"></div></div>
-            <div class="bg-white rounded-xl shadow-md p-4"><h3 class="text-lg font-bold text-yellow-600 mb-3 border-b-2 border-yellow-200 pb-2">Urgent & Not Important (Delegate)</h3><div id="quadrant-delegate" class="eisenhower-quadrant p-2 space-y-3 bg-yellow-50 dark:bg-yellow-900/30 rounded-md" data-quadrant="delegate"></div></div>
-            <div class="bg-white rounded-xl shadow-md p-4"><h3 class="text-lg font-bold text-green-600 mb-3 border-b-2 border-green-200 pb-2">Not Urgent & Not Important (Eliminate)</h3><div id="quadrant-eliminate" class="eisenhower-quadrant p-2 space-y-3 bg-green-50 dark:bg-green-900/30 rounded-md" data-quadrant="eliminate"></div></div>
+            <div class="bg-white rounded-xl shadow-md p-4"><h3 class="text-lg font-bold text-red-600 mb-3 border-b-2 border-red-200 pb-2">Urgent & Important (Do)</h3><div id="quadrant-do" class="eisenhower-quadrant p-2 space-y-3 bg-red-50 rounded-md" data-quadrant="do"></div></div>
+            <div class="bg-white rounded-xl shadow-md p-4"><h3 class="text-lg font-bold text-blue-600 mb-3 border-b-2 border-blue-200 pb-2">Important & Not Urgent (Schedule)</h3><div id="quadrant-schedule" class="eisenhower-quadrant p-2 space-y-3 bg-blue-50 rounded-md" data-quadrant="schedule"></div></div>
+            <div class="bg-white rounded-xl shadow-md p-4"><h3 class="text-lg font-bold text-yellow-600 mb-3 border-b-2 border-yellow-200 pb-2">Urgent & Not Important (Delegate)</h3><div id="quadrant-delegate" class="eisenhower-quadrant p-2 space-y-3 bg-yellow-50 rounded-md" data-quadrant="delegate"></div></div>
+            <div class="bg-white rounded-xl shadow-md p-4"><h3 class="text-lg font-bold text-green-600 mb-3 border-b-2 border-green-200 pb-2">Not Urgent & Not Important (Eliminate)</h3><div id="quadrant-eliminate" class="eisenhower-quadrant p-2 space-y-3 bg-green-50 rounded-md" data-quadrant="eliminate"></div></div>
         </div>
 
         <div id="table-view" class="hidden bg-white rounded-xl shadow-md p-6 overflow-x-auto">
@@ -591,7 +522,6 @@
                     button.classList.toggle('shadow-md', isActive);
                     button.classList.toggle('bg-transparent', !isActive);
                     button.classList.toggle('text-gray-600', !isActive);
-                    button.classList.toggle('dark:text-gray-300', !isActive);
                 });
             }
 
@@ -901,27 +831,27 @@
         function displayTasks(tasks) {
             taskList.innerHTML = '';
             if (tasks.length === 0) {
-                taskList.innerHTML = '<li class="text-center text-gray-500 dark:text-gray-400 py-4">No tasks match the current filters.</li>';
+                taskList.innerHTML = '<li class="text-center text-gray-500 py-4">No tasks match the current filters.</li>';
                 return;
             }
 
             tasks.forEach(task => {
                 const li = document.createElement('li');
-                li.className = 'bg-gray-50 dark:bg-gray-700 p-4 rounded-lg flex items-center justify-between shadow-sm flex-wrap';
+                li.className = 'bg-gray-50 p-4 rounded-lg flex items-center justify-between shadow-sm flex-wrap';
                 li.dataset.taskId = task.id;
 
                 const getLabelHtml = (label) => {
                     let classes = '';
-                    if (label === ACTIVE_TIMER_LABEL) classes = 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300 animate-pulse';
-                    else if (deviceLabels.includes(label)) classes = 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-300';
-                    else if (durationLabels.includes(label)) classes = 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
+                    if (label === ACTIVE_TIMER_LABEL) classes = 'bg-emerald-100 text-emerald-800 animate-pulse';
+                    else if (deviceLabels.includes(label)) classes = 'bg-teal-100 text-teal-800';
+                    else if (durationLabels.includes(label)) classes = 'bg-yellow-100 text-yellow-800';
                     else return ''; // Don't render unknown labels
                     return `<span class="text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full ${classes}">${label}</span>`;
                 };
                 const labelsHtml = task.labels.map(getLabelHtml).join('');
                 const completionBadge = isTaskMarkedComplete(task)
-                    ? '<span class="text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-300">Complete</span>'
-                    : '<span class="text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-200">Incomplete</span>';
+                    ? '<span class="text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full bg-emerald-100 text-emerald-800">Complete</span>'
+                    : '<span class="text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full bg-slate-200 text-slate-700">Incomplete</span>';
 
                 li.innerHTML = `
                     <span class="flex-grow mr-4">${task.content}</span>
@@ -1275,10 +1205,10 @@
         // --- Utility ---
         function getPriority(level) {
             const priorities = {
-                4: { text: 'P1', classes: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300' },
-                3: { text: 'P2', classes: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300' },
-                2: { text: 'P3', classes: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300' },
-                1: { text: 'P4', classes: 'bg-gray-200 text-gray-800 dark:bg-gray-600 dark:text-gray-300' }
+                4: { text: 'P1', classes: 'bg-red-100 text-red-800' },
+                3: { text: 'P2', classes: 'bg-orange-100 text-orange-800' },
+                2: { text: 'P3', classes: 'bg-blue-100 text-blue-800' },
+                1: { text: 'P4', classes: 'bg-gray-200 text-gray-800' }
             };
             return priorities[level] || priorities[1];
         }


### PR DESCRIPTION
## Summary
- remove the dark mode-specific styles and utility classes from the Todoist project planning page so it always renders in the light theme
- update JavaScript-generated class names to drop dark theme variants

## Testing
- not run (HTML change)

------
https://chatgpt.com/codex/tasks/task_e_68d9edaa019c83259d341a1c1cc6e49d