### PR TITLE
Add current focus areas and priority snapshot to LifeOS page

### DIFF
--- a/projects/lifeos.html
+++ b/projects/lifeos.html
@@ -149,6 +149,184 @@
         </div>
     </section>
 
+    <!-- Current Focus Areas -->
+    <section class="focus-areas">
+        <div class="container">
+            <h2>Current Focus Areas</h2>
+            <p class="section-intro">
+                LifeOS keeps every major initiative visible and grounded in purpose. Below is the living
+                snapshot of my most important areas, the goals driving them, and the projects currently in
+                motion.
+            </p>
+            <div class="focus-grid">
+                <div class="focus-card high-priority">
+                    <div class="focus-icon">🧠</div>
+                    <div class="focus-meta">
+                        <span class="focus-area">Career / JP Morgan</span>
+                        <span class="focus-priority">High Priority — Core Work Focus</span>
+                    </div>
+                    <h3>Goal</h3>
+                    <p class="focus-goal">Drive execution across modernization, migration, and consumer rollout while
+                        managing backlog and team culture.</p>
+                    <h3>Projects</h3>
+                    <ul>
+                        <li><strong>Backlog Management &amp; Sprint Planning (Top Priority):</strong> Manage backlog, communicate
+                            risks, track Agile metrics, create dependency tracking, automate JIRA reports, and lead weekly
+                            backlog reviews.</li>
+                        <li><strong>Consumer Migration Strategy (Business Banking Focus):</strong> Plan migration, clarify aggregator
+                            and support requirements, and ensure Enhanced Transaction Details API integration.</li>
+                        <li><strong>Team Culture &amp; Dynamics:</strong> Follow up on communication improvements, lead training, and
+                            reinforce team collaboration.</li>
+                        <li><strong>Adelante (Hispanic BRG):</strong> Maintain active participation and contribute initiatives that
+                            support Adelante’s goals.</li>
+                    </ul>
+                </div>
+                <div class="focus-card high-priority">
+                    <div class="focus-icon">🚀</div>
+                    <div class="focus-meta">
+                        <span class="focus-area">Entrepreneurship / AI Agency</span>
+                        <span class="focus-priority">High Priority — Growth Initiative</span>
+                    </div>
+                    <h3>Goal</h3>
+                    <p class="focus-goal">Launch and scale the AI agency while collaborating closely with my virtual assistant.</p>
+                    <h3>Projects</h3>
+                    <ul>
+                        <li><strong>AI Agency Launch:</strong> Define the business model, coordinate workflows with my VA, and
+                            build the client pipeline and outreach strategy.</li>
+                        <li><strong>AI Workflows &amp; Automation:</strong> Design AI-assisted flows for meeting and run notes, and
+                            explore tools like Cursor and Font for deeper integration.</li>
+                    </ul>
+                </div>
+                <div class="focus-card very-high-priority">
+                    <div class="focus-icon">🍽️</div>
+                    <div class="focus-meta">
+                        <span class="focus-area">Entrepreneurship / Cuculi</span>
+                        <span class="focus-priority">Very High Priority — Demo &amp; Leadership</span>
+                    </div>
+                    <h3>Goal</h3>
+                    <p class="focus-goal">Lead Cuculi’s AI development and deliver a polished Pulse NYC demo.</p>
+                    <h3>Projects</h3>
+                    <ul>
+                        <li><strong>Agentic NYC Presentation Demo (Top Priority):</strong> Craft a one-shot prompt, showcase agentic
+                            workflows, and prepare the attendee experience from demo flow to kickoff packet.</li>
+                        <li><strong>Nudge Notification Microservice:</strong> Guide engineering delivery of the AI-powered nudge API,
+                            manage architecture decisions, and review the microservice before the Monday sync.</li>
+                    </ul>
+                </div>
+                <div class="focus-card high-priority">
+                    <div class="focus-icon">🏠</div>
+                    <div class="focus-meta">
+                        <span class="focus-area">Homeostasis / Environment &amp; Finances</span>
+                        <span class="focus-priority">High Priority — Immediate Life Management</span>
+                    </div>
+                    <h3>Goal</h3>
+                    <p class="focus-goal">Clean, declutter, and bring financial order back online.</p>
+                    <h3>Projects</h3>
+                    <ul>
+                        <li><strong>Apartment Cleaning &amp; Airbnb Readiness:</strong> Deep clean, create daily checklists, and stage
+                            for hosting.</li>
+                        <li><strong>Finance Management:</strong> Pay rent, review balances, cancel subscriptions, and restore spending
+                            visibility.</li>
+                        <li><strong>Family Land Repossession Project:</strong> Research the inherited property, coordinate with the
+                            consul, and align family stakeholders.</li>
+                    </ul>
+                </div>
+                <div class="focus-card high-priority">
+                    <div class="focus-icon">🧍‍♂️</div>
+                    <div class="focus-meta">
+                        <span class="focus-area">Personal Development / Life Engineering</span>
+                        <span class="focus-priority">High Priority — Systems &amp; Habits</span>
+                    </div>
+                    <h3>Goal</h3>
+                    <p class="focus-goal">Redesign the Life Operating System to reinforce habits, reflection, and clarity.</p>
+                    <h3>Projects</h3>
+                    <ul>
+                        <li><strong>Life Operating System Revamp (Top Priority):</strong> Rebuild the productivity architecture with
+                            consistent rituals and reviews.</li>
+                        <li><strong>Morning &amp; Evening Rituals:</strong> Integrate meditation, reflection, journaling, and habit
+                            tracking into daily rhythms.</li>
+                        <li><strong>Reading &amp; Learning:</strong> Maintain a reading cadence and capture insights in my Second Brain.</li>
+                    </ul>
+                </div>
+                <div class="focus-card medium-priority">
+                    <div class="focus-icon">🏃</div>
+                    <div class="focus-meta">
+                        <span class="focus-area">Health &amp; Fitness</span>
+                        <span class="focus-priority">Medium Priority — Ongoing Routine</span>
+                    </div>
+                    <h3>Goal</h3>
+                    <p class="focus-goal">Build a sustainable and fun fitness rhythm.</p>
+                    <h3>Projects</h3>
+                    <ul>
+                        <li><strong>Marathon Preparation:</strong> Research pitfalls, design a social plan, and maintain running and gym
+                            cadence.</li>
+                        <li><strong>Meditation Practice:</strong> Resume daily meditation and connect it to LifeOS tracking.</li>
+                    </ul>
+                </div>
+                <div class="focus-card medium-priority">
+                    <div class="focus-icon">💬</div>
+                    <div class="focus-meta">
+                        <span class="focus-area">Relationships &amp; Social</span>
+                        <span class="focus-priority">Medium Priority — Growth &amp; Connection</span>
+                    </div>
+                    <h3>Goal</h3>
+                    <p class="focus-goal">Strengthen family bonds, friendships, and community involvement.</p>
+                    <h3>Projects</h3>
+                    <ul>
+                        <li><strong>Friend &amp; Family Management:</strong> Build systems for maintaining relationships and support
+                            relatives’ goals.</li>
+                        <li><strong>Social &amp; Event Engagement:</strong> Research seasonal events, stay active in Cuculi and Pulse NYC
+                            networks, and plan for upcoming gatherings.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Priority Summary -->
+    <section class="priority-summary">
+        <div class="container">
+            <h2>Priority Snapshot</h2>
+            <div class="summary-table-wrapper">
+                <table class="summary-table">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Area</th>
+                            <th>Project</th>
+                            <th>Priority</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td>1</td><td>Career</td><td>Backlog Management &amp; Sprint Planning</td><td>🔥 Top</td></tr>
+                        <tr><td>2</td><td>Career</td><td>Consumer Migration Strategy</td><td>🔥 High</td></tr>
+                        <tr><td>3</td><td>Career</td><td>Team Culture &amp; Dynamics</td><td>🔥 High</td></tr>
+                        <tr><td>4</td><td>Career</td><td>Adelante Engagement</td><td>⚡ Medium</td></tr>
+                        <tr><td>5</td><td>Entrepreneurship</td><td>AI Agency Launch</td><td>🔥 High</td></tr>
+                        <tr><td>6</td><td>Entrepreneurship</td><td>AI Workflows &amp; Automation</td><td>⚡ Medium</td></tr>
+                        <tr><td>7</td><td>Cuculi</td><td>Agentic NYC Demo</td><td>🚨 Top</td></tr>
+                        <tr><td>8</td><td>Cuculi</td><td>Nudge Notification Microservice</td><td>🔥 High</td></tr>
+                        <tr><td>9</td><td>Homeostasis</td><td>Apartment Cleaning &amp; Airbnb Readiness</td><td>🔥 High</td></tr>
+                        <tr><td>10</td><td>Finance</td><td>Financial Management</td><td>🔥 High</td></tr>
+                        <tr><td>11</td><td>Family</td><td>Land Repossession Project</td><td>⚡ Medium</td></tr>
+                        <tr><td>12</td><td>Life Engineering</td><td>LifeOS Revamp</td><td>🚨 Top</td></tr>
+                        <tr><td>13</td><td>Life Engineering</td><td>Rituals &amp; Habits</td><td>🔥 High</td></tr>
+                        <tr><td>14</td><td>Learning</td><td>Reading &amp; Study</td><td>⚡ Medium</td></tr>
+                        <tr><td>15</td><td>Fitness</td><td>Marathon Preparation</td><td>⚡ Medium</td></tr>
+                        <tr><td>16</td><td>Fitness</td><td>Meditation</td><td>⚡ Medium</td></tr>
+                        <tr><td>17</td><td>Relationships</td><td>Friend &amp; Family Management</td><td>🔥 High</td></tr>
+                        <tr><td>18</td><td>Social</td><td>Social &amp; Event Engagement</td><td>⚡ Medium</td></tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="summary-footer">
+                <p><strong>Total Projects:</strong> 18</p>
+                <p><strong>Top Priorities:</strong> Agentic NYC Demo (Cuculi), Backlog Management (Work), LifeOS Revamp (Personal
+                    System)</p>
+            </div>
+        </div>
+    </section>
+
     <!-- Technical Architecture -->
     <section class="technical-architecture">
         <div class="container">


### PR DESCRIPTION
## Summary
- add a Current Focus Areas section to the LifeOS project page with goals and detailed project lists for each life area
- include a Priority Snapshot table that captures all 18 projects and highlights the top priorities

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68e2aa8045e48325b7547c921c664788